### PR TITLE
feat(shared): build analyst foundations for persistent report workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ cargo run -p storage-strategist -- benchmark --paths fixtures --max-depth 3 --it
 cargo run -p storage-strategist -- parity --paths fixtures --max-depth 3
 cargo run -p storage-strategist -- plan --report storage-strategist-report.json --output scenario-plan.json
 cargo run -p storage-strategist -- diagnostics --report storage-strategist-report.json --output storage-strategist-diagnostics.json
+cargo run -p storage-strategist -- reports list
+cargo run -p storage-strategist -- reports import --path storage-strategist-report.json
+cargo run -p storage-strategist -- reports show --scan-id <scan-id>
+cargo run -p storage-strategist -- reports diff --left <scan-id> --right <scan-id> --output report-diff.json
 ```
 
 Backend values:
@@ -129,6 +133,10 @@ npm run tauri dev
   - projections sum `estimated_impact.space_saving_bytes` for included policy-safe recommendations
 - Diagnostics bundle:
   - `diagnostics` command exports report + doctor snapshot + environment metadata for support workflows
+- Local report store:
+  - completed scans are also indexed into a local report library keyed by `scan_id`
+  - `reports list|import|show|diff` expose saved-report and compare workflows for CLI users
+  - desktop uses the same store for reopen/import/compare flows
 
 ## Notes on `parallel-disk-usage` Inspiration
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -5,6 +5,7 @@ This app is the read-only review UI track for `storage-strategist`.
 ## Scope
 
 - Guided path selection before scan start.
+- Home/library workflow for reopening imported or previously saved reports.
 - Live scan progress (events + session polling).
 - Results workbench:
   - Disks
@@ -39,4 +40,5 @@ npm run test:e2e
 
 - Uses `crates/service` for scan/recommend/report APIs.
 - UI is intentionally advisory and read-only in all current phases.
+- Saved reports are indexed into the shared local report store and can be reopened or compared without rescanning.
 - E2E smoke tests mock the Tauri command bridge to validate setup/scanning/results/doctor flows in CI.

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,7 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1617,6 +1623,21 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1960,6 +1981,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,7 +2005,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2564,6 +2595,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2704,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-xml"
@@ -3311,6 +3361,7 @@ dependencies = [
  "blake3",
  "chrono",
  "globset",
+ "image",
  "parallel-disk-usage",
  "serde",
  "serde_json",
@@ -3617,7 +3668,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4071,7 +4122,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -5107,3 +5158,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -3,14 +3,19 @@
 use std::path::PathBuf;
 
 use storage_strategist_core::{
-    DiagnosticsBundle, DoctorInfo, RecommendationBundle, Report, ScanProgressEvent, ScenarioPlan,
+    DiagnosticsBundle, DoctorInfo, RecommendationBundle, Report, ReportDiff, ReportImportResult,
+    ReportSummary, ScanProgressEvent, ScenarioPlan,
 };
 use storage_strategist_service::{
-    cancel_scan as service_cancel_scan, doctor as service_doctor, export_diagnostics_bundle as service_export_diagnostics_bundle,
-    generate_recommendations_from_report, get_scan_session as service_get_scan_session,
-    load_report as service_load_report, poll_scan_events as service_poll_scan_events, start_scan as service_start_scan,
-    plan_scenarios_from_report as service_plan_scenarios_from_report, CancelScanResponse, ScanRequest,
-    ScanSessionSnapshot,
+    cancel_scan as service_cancel_scan, compare_reports as service_compare_reports,
+    doctor as service_doctor, export_diagnostics_bundle as service_export_diagnostics_bundle,
+    export_markdown_summary as service_export_markdown_summary,
+    export_report_diff as service_export_report_diff, generate_recommendations_from_report,
+    get_report as service_get_report, get_scan_session as service_get_scan_session,
+    import_report as service_import_report, list_reports as service_list_reports,
+    load_report as service_load_report, plan_scenarios_from_report as service_plan_scenarios_from_report,
+    poll_scan_events as service_poll_scan_events, start_scan as service_start_scan,
+    CancelScanResponse, ScanRequest, ScanSessionSnapshot,
 };
 
 #[tauri::command]
@@ -39,6 +44,26 @@ fn load_report(path: String) -> Result<Report, String> {
 }
 
 #[tauri::command]
+fn list_reports() -> Result<Vec<ReportSummary>, String> {
+    service_list_reports(None).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+fn get_report(scan_id: String) -> Result<Report, String> {
+    service_get_report(&scan_id, None).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+fn import_report(path: String) -> Result<ReportImportResult, String> {
+    service_import_report(path, None).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+fn compare_reports(left_scan_id: String, right_scan_id: String) -> Result<ReportDiff, String> {
+    service_compare_reports(&left_scan_id, &right_scan_id, None).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
 fn generate_recommendations(report: Report) -> Result<RecommendationBundle, String> {
     Ok(generate_recommendations_from_report(&report))
 }
@@ -63,6 +88,16 @@ fn export_diagnostics_bundle(
 }
 
 #[tauri::command]
+fn export_markdown_summary(report: Report, output_path: String) -> Result<(), String> {
+    service_export_markdown_summary(&report, output_path).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+fn export_report_diff(diff: ReportDiff, output_path: String) -> Result<(), String> {
+    service_export_report_diff(&diff, output_path).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
 fn doctor() -> DoctorInfo {
     service_doctor()
 }
@@ -75,9 +110,15 @@ fn main() {
             get_scan_session,
             cancel_scan,
             load_report,
+            list_reports,
+            get_report,
+            import_report,
+            compare_reports,
             generate_recommendations,
             plan_scenarios,
             export_diagnostics_bundle,
+            export_markdown_summary,
+            export_report_diff,
             doctor,
         ])
         .run(tauri::generate_context!())

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,10 +3,16 @@ import { open } from "@tauri-apps/plugin-dialog";
 
 import {
   cancelScan,
+  compareReports,
   doctor,
   exportDiagnosticsBundle,
+  exportMarkdownSummary,
+  exportReportDiff,
   generateRecommendations,
+  getReport,
   getScanSession,
+  importReport,
+  listReports,
   loadReport,
   planScenarios,
   pollScanEvents,
@@ -16,6 +22,8 @@ import type {
   DoctorInfo,
   PolicyDecision,
   Report,
+  ReportDiff,
+  ReportSummary,
   RuleTrace,
   ScenarioPlan,
   ScanProgressEvent,
@@ -23,7 +31,7 @@ import type {
   ScanSessionSnapshot,
 } from "./types";
 
-type Screen = "setup" | "scanning" | "results" | "doctor";
+type Screen = "setup" | "scanning" | "results" | "compare" | "doctor";
 type ResultTab =
   | "disks"
   | "usage"
@@ -36,6 +44,15 @@ type ResultTab =
 const DEFAULT_OUTPUT = "storage-strategist-report.json";
 
 type RuleTraceFilterStatus = "all" | "emitted" | "rejected" | "skipped";
+type RecommendationPolicyFilter = "all" | "safe" | "blocked";
+type RecommendationEvidenceFilter =
+  | "all"
+  | "disk"
+  | "directory"
+  | "duplicate_group"
+  | "history_delta"
+  | "warning"
+  | "other";
 
 const RULE_TRACE_STATUS_OPTIONS: RuleTraceFilterStatus[] = [
   "all",
@@ -65,12 +82,34 @@ function formatConfidence(confidence: number | null | undefined): string {
   return `${(confidence * 100).toFixed(1)}%`;
 }
 
+function formatSignedBytes(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined) {
+    return "n/a";
+  }
+  const sign = bytes < 0 ? "-" : "+";
+  return `${sign}${formatBytes(Math.abs(bytes))}`;
+}
+
 function deriveDiagnosticsOutputPath(sourcePath?: string): string {
   const base = sourcePath?.trim() || DEFAULT_OUTPUT;
   if (base.toLowerCase().endsWith(".json")) {
     return `${base.slice(0, -5)}.diagnostics.json`;
   }
   return `${base}.diagnostics.json`;
+}
+
+function deriveMarkdownOutputPath(sourcePath?: string): string {
+  const base = sourcePath?.trim() || DEFAULT_OUTPUT;
+  if (base.toLowerCase().endsWith(".json")) {
+    return `${base.slice(0, -5)}.md`;
+  }
+  return `${base}.md`;
+}
+
+function deriveDiffOutputPath(leftScanId?: string, rightScanId?: string): string {
+  const left = leftScanId?.trim() || "left";
+  const right = rightScanId?.trim() || "right";
+  return `${left}-to-${right}.diff.json`;
 }
 
 function App() {
@@ -90,6 +129,10 @@ function App() {
   const [session, setSession] = useState<ScanSessionSnapshot | null>(null);
   const [events, setEvents] = useState<ScanProgressEvent[]>([]);
   const [report, setReport] = useState<Report | null>(null);
+  const [reportLibrary, setReportLibrary] = useState<ReportSummary[]>([]);
+  const [reportDiff, setReportDiff] = useState<ReportDiff | null>(null);
+  const [leftCompareId, setLeftCompareId] = useState<string>("");
+  const [rightCompareId, setRightCompareId] = useState<string>("");
   const [scenarioPlan, setScenarioPlan] = useState<ScenarioPlan | null>(null);
   const [doctorInfo, setDoctorInfo] = useState<DoctorInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -97,6 +140,30 @@ function App() {
   const [selectedRecommendationId, setSelectedRecommendationId] = useState<string | null>(null);
   const [traceStatusFilter, setTraceStatusFilter] = useState<RuleTraceFilterStatus>("all");
   const [traceRecommendationFilter, setTraceRecommendationFilter] = useState<string>("all");
+  const [usageFilter, setUsageFilter] = useState("");
+  const [duplicateFilter, setDuplicateFilter] = useState("");
+  const [recommendationFilter, setRecommendationFilter] = useState("");
+  const [recommendationPolicyFilter, setRecommendationPolicyFilter] =
+    useState<RecommendationPolicyFilter>("all");
+  const [recommendationEvidenceFilter, setRecommendationEvidenceFilter] =
+    useState<RecommendationEvidenceFilter>("all");
+
+  const refreshReportLibrary = async () => {
+    const reports = await listReports();
+    setReportLibrary(reports);
+    if (!leftCompareId && reports[0]) {
+      setLeftCompareId(reports[0].scan_id);
+    }
+    if (!rightCompareId && reports[1]) {
+      setRightCompareId(reports[1].scan_id);
+    }
+  };
+
+  useEffect(() => {
+    void refreshReportLibrary().catch((libraryError) => {
+      setError(String(libraryError));
+    });
+  }, []);
 
   useEffect(() => {
     if (screen !== "scanning" || !scanId) {
@@ -125,24 +192,18 @@ function App() {
         }
 
         if (snapshot.status === "completed") {
-          const reportPath = snapshot.report_path ?? output;
-          const loaded = await loadReport(reportPath);
-          const bundle = await generateRecommendations(loaded);
-          const nextReport = { ...loaded, recommendations: bundle.recommendations };
-          const nextScenarioPlan = await planScenarios(nextReport);
+          const loaded =
+            snapshot.report_path !== undefined && snapshot.report_path !== null
+              ? await loadReport(snapshot.report_path)
+              : await getReport(scanId);
 
           if (!isActive) {
             return;
           }
 
-          setReport(nextReport);
-          setScenarioPlan(nextScenarioPlan);
-          setSelectedRecommendationId(nextReport.recommendations[0]?.id ?? null);
-          setTraceStatusFilter("all");
-          setTraceRecommendationFilter("all");
+          await loadWorkbenchReport(loaded);
+          await refreshReportLibrary();
           setNotice(null);
-          setTab("recommendations");
-          setScreen("results");
         }
 
         if (snapshot.status === "failed") {
@@ -258,6 +319,130 @@ function App() {
     });
   }, [report, traceStatusFilter, traceRecommendationFilter]);
 
+  const filteredUsage = useMemo(() => {
+    const query = usageFilter.trim().toLowerCase();
+    const paths = report?.paths ?? [];
+    if (!query) {
+      return paths;
+    }
+    return paths.filter((path) => path.root_path.toLowerCase().includes(query));
+  }, [report, usageFilter]);
+
+  const filteredDuplicates = useMemo(() => {
+    const query = duplicateFilter.trim().toLowerCase();
+    const duplicates = report?.duplicates ?? [];
+    if (!query) {
+      return duplicates;
+    }
+    return duplicates.filter((duplicate) => {
+      const label = duplicate.intent?.label?.toLowerCase() ?? "";
+      return (
+        label.includes(query) ||
+        duplicate.hash.toLowerCase().includes(query) ||
+        duplicate.files.some((file) => file.path.toLowerCase().includes(query))
+      );
+    });
+  }, [report, duplicateFilter]);
+
+  const filteredRecommendations = useMemo(() => {
+    const query = recommendationFilter.trim().toLowerCase();
+    const recommendations = report?.recommendations ?? [];
+    return recommendations.filter((recommendation) => {
+      const queryMatches =
+        !query ||
+        recommendation.title.toLowerCase().includes(query) ||
+        recommendation.rationale.toLowerCase().includes(query) ||
+        recommendation.id.toLowerCase().includes(query);
+      const policyMatches =
+        recommendationPolicyFilter === "all" ||
+        (recommendationPolicyFilter === "safe" && recommendation.policy_safe) ||
+        (recommendationPolicyFilter === "blocked" && !recommendation.policy_safe);
+      const evidenceMatches =
+        recommendationEvidenceFilter === "all" ||
+        recommendation.evidence.some(
+          (evidence) => evidence.kind === recommendationEvidenceFilter
+        );
+      return queryMatches && policyMatches && evidenceMatches;
+    });
+  }, [report, recommendationEvidenceFilter, recommendationFilter, recommendationPolicyFilter]);
+
+  const loadWorkbenchReport = async (loaded: Report) => {
+    const bundle = await generateRecommendations(loaded);
+    const nextReport = {
+      ...loaded,
+      recommendations: bundle.recommendations,
+      policy_decisions: bundle.policy_decisions,
+      rule_traces: bundle.rule_traces,
+    };
+    const nextScenarioPlan = await planScenarios(nextReport);
+
+    setReport(nextReport);
+    setScanId(nextReport.scan_id);
+    setSession(null);
+    setScenarioPlan(nextScenarioPlan);
+    setSelectedRecommendationId(nextReport.recommendations[0]?.id ?? null);
+    setTraceStatusFilter("all");
+    setTraceRecommendationFilter("all");
+    setRecommendationFilter("");
+    setRecommendationPolicyFilter("all");
+    setRecommendationEvidenceFilter("all");
+    setUsageFilter("");
+    setDuplicateFilter("");
+    setReportDiff(null);
+    setTab("recommendations");
+    setScreen("results");
+  };
+
+  const openStoredReport = async (storedScanId: string) => {
+    setError(null);
+    setNotice(null);
+    try {
+      const storedReport = await getReport(storedScanId);
+      await loadWorkbenchReport(storedReport);
+      setNotice(`Opened saved report ${storedScanId}.`);
+    } catch (storedReportError) {
+      setError(String(storedReportError));
+    }
+  };
+
+  const importExistingReport = async () => {
+    setError(null);
+    setNotice(null);
+    try {
+      const selection = await open({
+        directory: false,
+        multiple: false,
+        filters: [{ name: "JSON Reports", extensions: ["json"] }],
+      });
+      if (!selection || Array.isArray(selection)) {
+        return;
+      }
+      const result = await importReport(selection);
+      await refreshReportLibrary();
+      await openStoredReport(result.summary.scan_id);
+      setNotice(`Imported ${result.summary.scan_id} into the local report library.`);
+    } catch (importError) {
+      setError(String(importError));
+    }
+  };
+
+  const runCompare = async () => {
+    if (!leftCompareId || !rightCompareId || leftCompareId === rightCompareId) {
+      setError("Select two different stored reports to compare.");
+      return;
+    }
+
+    setError(null);
+    setNotice(null);
+    try {
+      const diff = await compareReports(leftCompareId, rightCompareId);
+      setReportDiff(diff);
+      setScreen("compare");
+    } catch (compareError) {
+      setError(String(compareError));
+    }
+  };
+
   const start = async () => {
     setError(null);
     setNotice(null);
@@ -280,6 +465,7 @@ function App() {
       progress_interval_ms: 250,
       incremental_cache: true,
       cache_ttl_seconds: 900,
+      record_history: true,
     };
 
     try {
@@ -329,6 +515,40 @@ function App() {
       );
     } catch (bundleError) {
       setError(String(bundleError));
+    }
+  };
+
+  const exportMarkdown = async () => {
+    if (!report) {
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    try {
+      const sourcePath = session?.report_path ?? output;
+      const outputPath = deriveMarkdownOutputPath(sourcePath);
+      await exportMarkdownSummary(report, outputPath);
+      setNotice(`Markdown review summary written to ${outputPath}.`);
+    } catch (markdownError) {
+      setError(String(markdownError));
+    }
+  };
+
+  const exportCompareJson = async () => {
+    if (!reportDiff) {
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    try {
+      const outputPath = deriveDiffOutputPath(
+        reportDiff.left_scan_id,
+        reportDiff.right_scan_id
+      );
+      await exportReportDiff(reportDiff, outputPath);
+      setNotice(`Compare JSON written to ${outputPath}.`);
+    } catch (diffError) {
+      setError(String(diffError));
     }
   };
 
@@ -382,7 +602,81 @@ function App() {
 
       {screen === "setup" ? (
         <section className="panel">
-          <h2>Guided Path Selection</h2>
+          <h2>Home And Guided Path Selection</h2>
+          <p>Select local paths first, or reopen/import a stored report from the local library.</p>
+
+          <article className="card">
+            <div className="title-row">
+              <h3>Report Library</h3>
+              <button onClick={importExistingReport}>Import Report...</button>
+            </div>
+            <p className="muted">
+              Reopen saved scans, compare two reports, or import an exported JSON report into the local workbench.
+            </p>
+            {reportLibrary.length === 0 ? (
+              <p className="muted">No saved reports yet.</p>
+            ) : (
+              <>
+                <div className="row two-col">
+                  <label>
+                    Compare left
+                    <select
+                      value={leftCompareId}
+                      onChange={(event) => setLeftCompareId(event.target.value)}
+                    >
+                      <option value="">select report</option>
+                      {reportLibrary.map((item) => (
+                        <option key={`left-${item.scan_id}`} value={item.scan_id}>
+                          {item.scan_id} - {item.generated_at}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    Compare right
+                    <select
+                      value={rightCompareId}
+                      onChange={(event) => setRightCompareId(event.target.value)}
+                    >
+                      <option value="">select report</option>
+                      {reportLibrary.map((item) => (
+                        <option key={`right-${item.scan_id}`} value={item.scan_id}>
+                          {item.scan_id} - {item.generated_at}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <div className="row end">
+                  <button onClick={runCompare} disabled={!leftCompareId || !rightCompareId}>
+                    Compare Stored Reports
+                  </button>
+                </div>
+                <div className="scroll-block">
+                  {reportLibrary.map((item) => (
+                    <article key={item.scan_id} className="card">
+                      <div className="title-row">
+                        <h3>{item.scan_id}</h3>
+                        <span className="badge">{item.backend}</span>
+                      </div>
+                      <p>{item.generated_at}</p>
+                      <p>
+                        roots {item.roots.join(", ")} | warnings {item.warnings_count} | recommendations{" "}
+                        {item.recommendation_count}
+                      </p>
+                      <p>stored at {item.stored_report_path}</p>
+                      <p>source path {item.source_path ?? "library-generated"}</p>
+                      <div className="row end">
+                        <button onClick={() => openStoredReport(item.scan_id)}>Open Report</button>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </>
+            )}
+          </article>
+
+          <h3>New Scan</h3>
           <p>Select local paths first. Cloud/network/virtual targets are excluded from placement recommendations.</p>
 
           <div className="row">
@@ -516,7 +810,10 @@ function App() {
         <section className="panel">
           <div className="title-row">
             <h2>Results Workbench</h2>
-            <button onClick={exportDiagnostics}>Export Diagnostics Bundle</button>
+            <div className="row">
+              <button onClick={exportMarkdown}>Export Markdown Summary</button>
+              <button onClick={exportDiagnostics}>Export Diagnostics Bundle</button>
+            </div>
           </div>
           <p>
             Report {report.report_version} generated at {report.generated_at}
@@ -576,7 +873,14 @@ function App() {
 
           {tab === "usage" ? (
             <div className="scroll-block">
-              {(report.paths ?? []).map((path) => (
+              <div className="row">
+                <input
+                  value={usageFilter}
+                  onChange={(event) => setUsageFilter(event.target.value)}
+                  placeholder="Filter roots or paths"
+                />
+              </div>
+              {filteredUsage.map((path) => (
                 <article key={path.root_path} className="card">
                   <h3>{path.root_path}</h3>
                   <p>
@@ -602,7 +906,14 @@ function App() {
 
           {tab === "duplicates" ? (
             <div className="scroll-block">
-              {(report.duplicates ?? []).map((dup) => (
+              <div className="row">
+                <input
+                  value={duplicateFilter}
+                  onChange={(event) => setDuplicateFilter(event.target.value)}
+                  placeholder="Filter by hash, label, or file path"
+                />
+              </div>
+              {filteredDuplicates.map((dup) => (
                 <article key={`${dup.hash}-${dup.size_bytes}`} className="card">
                   <h3>{dup.intent?.label ?? "duplicate"}</h3>
                   <p>
@@ -659,12 +970,55 @@ function App() {
           {tab === "recommendations" ? (
             <div className="split-pane">
               <div className="list-pane">
-                <h3>Recommendations ({report.recommendations.length})</h3>
+                <h3>Recommendations ({filteredRecommendations.length})</h3>
+                <div className="row">
+                  <input
+                    value={recommendationFilter}
+                    onChange={(event) => setRecommendationFilter(event.target.value)}
+                    placeholder="Search recommendation title, id, or rationale"
+                  />
+                </div>
+                <div className="row two-col">
+                  <label>
+                    Policy
+                    <select
+                      value={recommendationPolicyFilter}
+                      onChange={(event) =>
+                        setRecommendationPolicyFilter(
+                          event.target.value as RecommendationPolicyFilter
+                        )
+                      }
+                    >
+                      <option value="all">all</option>
+                      <option value="safe">safe</option>
+                      <option value="blocked">blocked</option>
+                    </select>
+                  </label>
+                  <label>
+                    Evidence
+                    <select
+                      value={recommendationEvidenceFilter}
+                      onChange={(event) =>
+                        setRecommendationEvidenceFilter(
+                          event.target.value as RecommendationEvidenceFilter
+                        )
+                      }
+                    >
+                      <option value="all">all</option>
+                      <option value="disk">disk</option>
+                      <option value="directory">directory</option>
+                      <option value="duplicate_group">duplicate group</option>
+                      <option value="history_delta">history delta</option>
+                      <option value="warning">warning</option>
+                      <option value="other">other</option>
+                    </select>
+                  </label>
+                </div>
                 <div className="scroll-block">
-                  {report.recommendations.length === 0 ? (
+                  {filteredRecommendations.length === 0 ? (
                     <p className="muted">No recommendations were produced for this report.</p>
                   ) : null}
-                  {report.recommendations.map((recommendation) => {
+                  {filteredRecommendations.map((recommendation) => {
                     const isActive = recommendation.id === selectedRecommendationId;
                     return (
                       <button
@@ -736,6 +1090,35 @@ function App() {
                         performance note {selectedRecommendation.estimated_impact.performance ?? "none"}
                       </p>
                       <p>risk notes {selectedRecommendation.estimated_impact.risk_notes ?? "none"}</p>
+                    </article>
+
+                    <article className="card">
+                      <h3>Evidence ({selectedRecommendation.evidence.length})</h3>
+                      {selectedRecommendation.evidence.length === 0 ? (
+                        <p className="muted">No structured evidence attached.</p>
+                      ) : null}
+                      {selectedRecommendation.evidence.map((evidence, index) => (
+                        <div key={`${evidence.label}-${index}`} className="detail-block">
+                          <p>
+                            <strong>{evidence.label}</strong>{" "}
+                            <span className="badge">{evidence.kind}</span>
+                          </p>
+                          <p>{evidence.detail}</p>
+                          {evidence.mount_point ? <p>mount {evidence.mount_point}</p> : null}
+                          {evidence.path ? <p>path {evidence.path}</p> : null}
+                          {evidence.duplicate_hash ? <p>duplicate {evidence.duplicate_hash}</p> : null}
+                        </div>
+                      ))}
+                    </article>
+
+                    <article className="card">
+                      <h3>Review Steps</h3>
+                      {selectedRecommendation.next_steps.length === 0 ? (
+                        <p className="muted">No follow-up guidance recorded.</p>
+                      ) : null}
+                      {selectedRecommendation.next_steps.map((step, index) => (
+                        <p key={`${selectedRecommendation.id}-step-${index}`}>{step}</p>
+                      ))}
                     </article>
 
                     <article className="card">
@@ -920,6 +1303,96 @@ function App() {
               </ul>
             </>
           ) : null}
+        </section>
+      ) : null}
+
+      {screen === "compare" && reportDiff ? (
+        <section className="panel">
+          <div className="title-row">
+            <h2>Report Compare</h2>
+            <div className="row">
+              <button onClick={exportCompareJson}>Export Compare JSON</button>
+              <button onClick={() => setScreen("setup")}>Back To Library</button>
+            </div>
+          </div>
+          <p>
+            {reportDiff.left_scan_id} ({reportDiff.left_generated_at}) {"->"} {reportDiff.right_scan_id} (
+            {reportDiff.right_generated_at})
+          </p>
+          <article className="card">
+            <h3>Overview</h3>
+            <p>duplicate waste delta {formatSignedBytes(reportDiff.duplicate_wasted_bytes_delta)}</p>
+            <p>
+              disk changes {reportDiff.disk_diffs.length} | path changes {reportDiff.path_diffs.length} |
+              recommendation changes {reportDiff.recommendation_changes.length}
+            </p>
+          </article>
+
+          <div className="split-pane">
+            <div className="list-pane">
+              <article className="card">
+                <h3>Disk Changes</h3>
+                {reportDiff.disk_diffs.length === 0 ? (
+                  <p className="muted">No disk free-space changes detected.</p>
+                ) : null}
+                {reportDiff.disk_diffs.map((disk) => (
+                  <div key={disk.mount_point} className="detail-block">
+                    <p>
+                      <strong>{disk.mount_point}</strong> {disk.name ?? ""}
+                    </p>
+                    <p>
+                      left {formatBytes(disk.left_free_space_bytes)} | right{" "}
+                      {formatBytes(disk.right_free_space_bytes)}
+                    </p>
+                    <p>delta {formatSignedBytes(disk.free_space_delta_bytes)}</p>
+                  </div>
+                ))}
+              </article>
+            </div>
+
+            <div className="inspector-pane">
+              <article className="card">
+                <h3>Path Growth</h3>
+                {reportDiff.path_diffs.length === 0 ? (
+                  <p className="muted">No path growth or shrinkage detected.</p>
+                ) : null}
+                {reportDiff.path_diffs.map((path) => (
+                  <div key={path.root_path} className="detail-block">
+                    <p>
+                      <strong>{path.root_path}</strong>
+                    </p>
+                    <p>
+                      left {formatBytes(path.left_total_size_bytes)} | right{" "}
+                      {formatBytes(path.right_total_size_bytes)}
+                    </p>
+                    <p>delta {formatSignedBytes(path.total_size_delta_bytes)}</p>
+                  </div>
+                ))}
+              </article>
+
+              <article className="card">
+                <h3>Recommendation Changes</h3>
+                {reportDiff.recommendation_changes.length === 0 ? (
+                  <p className="muted">No recommendation changes detected.</p>
+                ) : null}
+                {reportDiff.recommendation_changes.map((change, index) => (
+                  <div key={`${change.id}-${change.change}-${index}`} className="detail-block">
+                    <p>
+                      <strong>{change.id}</strong> <span className="badge">{change.change}</span>
+                    </p>
+                    <p>
+                      confidence {formatConfidence(change.left_confidence)} {"->"}{" "}
+                      {formatConfidence(change.right_confidence)}
+                    </p>
+                    <p>
+                      target {change.left_target_mount ?? "none"} {"->"}{" "}
+                      {change.right_target_mount ?? "none"}
+                    </p>
+                  </div>
+                ))}
+              </article>
+            </div>
+          </div>
         </section>
       ) : null}
     </main>

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -5,6 +5,9 @@ import type {
   DoctorInfo,
   RecommendationBundle,
   Report,
+  ReportDiff,
+  ReportImportResult,
+  ReportSummary,
   ScenarioPlan,
   ScanProgressEvent,
   ScanRequest,
@@ -39,6 +42,25 @@ export async function loadReport(path: string): Promise<Report> {
   return invoke<Report>("load_report", { path });
 }
 
+export async function listReports(): Promise<ReportSummary[]> {
+  return invoke<ReportSummary[]>("list_reports");
+}
+
+export async function getReport(scanId: string): Promise<Report> {
+  return invoke<Report>("get_report", { scanId });
+}
+
+export async function importReport(path: string): Promise<ReportImportResult> {
+  return invoke<ReportImportResult>("import_report", { path });
+}
+
+export async function compareReports(
+  leftScanId: string,
+  rightScanId: string
+): Promise<ReportDiff> {
+  return invoke<ReportDiff>("compare_reports", { leftScanId, rightScanId });
+}
+
 export async function generateRecommendations(
   report: Report
 ): Promise<RecommendationBundle> {
@@ -58,6 +80,26 @@ export async function exportDiagnosticsBundle(
     report,
     outputPath,
     sourceReportPath,
+  });
+}
+
+export async function exportMarkdownSummary(
+  report: Report,
+  outputPath: string
+): Promise<void> {
+  await invoke("export_markdown_summary", {
+    report,
+    outputPath,
+  });
+}
+
+export async function exportReportDiff(
+  diff: ReportDiff,
+  outputPath: string
+): Promise<void> {
+  await invoke("export_report_diff", {
+    diff,
+    outputPath,
   });
 }
 

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -16,6 +16,8 @@ export interface ScanRequest {
   incremental_cache?: boolean;
   cache_dir?: string;
   cache_ttl_seconds?: number;
+  record_history?: boolean;
+  report_store_dir?: string;
 }
 
 export interface ScanProgressEvent {
@@ -54,8 +56,19 @@ export interface Recommendation {
   policy_safe: boolean;
   policy_rules_applied: string[];
   policy_rules_blocked: string[];
+  evidence: RecommendationEvidence[];
+  next_steps: string[];
   estimated_impact: EstimatedImpact;
   risk_level: RiskLevel;
+}
+
+export interface RecommendationEvidence {
+  kind: "disk" | "directory" | "duplicate_group" | "history_delta" | "warning" | "other";
+  label: string;
+  detail: string;
+  path?: string | null;
+  mount_point?: string | null;
+  duplicate_hash?: string | null;
 }
 
 export interface EstimatedImpact {
@@ -132,6 +145,69 @@ export interface Report {
   warnings: string[];
 }
 
+export interface ReportSummary {
+  scan_id: string;
+  generated_at: string;
+  report_version: string;
+  roots: string[];
+  backend: "native" | "pdu_library";
+  warnings_count: number;
+  recommendation_count: number;
+  stored_report_path: string;
+  source_path?: string | null;
+  imported: boolean;
+}
+
+export interface ReportImportResult {
+  summary: ReportSummary;
+}
+
+export interface DiskDiff {
+  mount_point: string;
+  name?: string | null;
+  left_free_space_bytes?: number | null;
+  right_free_space_bytes?: number | null;
+  free_space_delta_bytes: number;
+}
+
+export interface PathDiff {
+  root_path: string;
+  left_total_size_bytes?: number | null;
+  right_total_size_bytes?: number | null;
+  total_size_delta_bytes: number;
+  left_file_count?: number | null;
+  right_file_count?: number | null;
+  file_count_delta: number;
+}
+
+export interface RecommendationChange {
+  id: string;
+  change:
+    | "added"
+    | "removed"
+    | "confidence_changed"
+    | "target_changed"
+    | "risk_changed"
+    | "rationale_changed";
+  left_confidence?: number | null;
+  right_confidence?: number | null;
+  left_target_mount?: string | null;
+  right_target_mount?: string | null;
+  left_risk_level?: RiskLevel | null;
+  right_risk_level?: RiskLevel | null;
+}
+
+export interface ReportDiff {
+  left_scan_id: string;
+  right_scan_id: string;
+  left_generated_at: string;
+  right_generated_at: string;
+  duplicate_wasted_bytes_delta: number;
+  disk_diffs: DiskDiff[];
+  path_diffs: PathDiff[];
+  recommendation_changes: RecommendationChange[];
+}
+
 export interface DoctorInfo {
   os: string;
   arch: string;
@@ -144,6 +220,9 @@ export interface DoctorInfo {
 
 export interface RecommendationBundle {
   recommendations: Recommendation[];
+  policy_decisions?: PolicyDecision[];
+  rule_traces?: RuleTrace[];
+  contradiction_count?: number;
 }
 
 export interface ScenarioRiskMix {

--- a/apps/desktop/tests/smoke.spec.ts
+++ b/apps/desktop/tests/smoke.spec.ts
@@ -47,6 +47,15 @@ const mockReport = {
         risk_notes: "Avoids non-local target suggestions.",
       },
       risk_level: "low",
+      evidence: [
+        {
+          kind: "disk",
+          label: "Excluded destination",
+          detail: "Fixture evidence",
+          mount_point: "D:\\",
+        },
+      ],
+      next_steps: ["Review the linked evidence before taking action."],
     },
   ],
   policy_decisions: [
@@ -119,9 +128,33 @@ const mockEvents = [
   },
 ];
 
+const mockReportSummary = {
+  scan_id: mockReport.scan_id,
+  generated_at: mockReport.generated_at,
+  report_version: mockReport.report_version,
+  roots: ["D:\\Demo"],
+  backend: "native",
+  warnings_count: 0,
+  recommendation_count: mockReport.recommendations.length,
+  stored_report_path: "mock-report.json",
+  source_path: "mock-report.json",
+  imported: false,
+};
+
+const mockReportDiff = {
+  left_scan_id: "scan-left",
+  right_scan_id: "scan-right",
+  left_generated_at: "2026-02-11T00:00:00Z",
+  right_generated_at: "2026-02-12T00:00:00Z",
+  duplicate_wasted_bytes_delta: 1024,
+  disk_diffs: [],
+  path_diffs: [],
+  recommendation_changes: [],
+};
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(
-    ({ report, doctor, events, scenarioPlan }) => {
+    ({ report, doctor, events, scenarioPlan, reportSummary, reportDiff }) => {
       let sessionCalls = 0;
       let eventCalls = 0;
       const scanId = report.scan_id;
@@ -155,8 +188,21 @@ test.beforeEach(async ({ page }) => {
               };
             case "load_report":
               return report;
+            case "list_reports":
+              return [reportSummary];
+            case "get_report":
+              return report;
+            case "import_report":
+              return { summary: reportSummary };
+            case "compare_reports":
+              return reportDiff;
             case "generate_recommendations":
-              return { recommendations: report.recommendations };
+              return {
+                recommendations: report.recommendations,
+                policy_decisions: report.policy_decisions,
+                rule_traces: report.rule_traces,
+                contradiction_count: 0,
+              };
             case "plan_scenarios":
               return scenarioPlan;
             case "doctor":
@@ -182,14 +228,21 @@ test.beforeEach(async ({ page }) => {
         },
       };
     },
-    { report: mockReport, doctor: mockDoctor, events: mockEvents, scenarioPlan: mockScenarioPlan }
+    {
+      report: mockReport,
+      doctor: mockDoctor,
+      events: mockEvents,
+      scenarioPlan: mockScenarioPlan,
+      reportSummary: mockReportSummary,
+      reportDiff: mockReportDiff,
+    }
   );
 });
 
 test("setup to results to doctor smoke flow", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Guided Path Selection" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Home And Guided Path Selection" })).toBeVisible();
 
   await page.getByPlaceholder(/Add path/).fill("D:\\Demo");
   await page.getByRole("button", { name: "Add Path" }).click();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,7 +7,9 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::Serialize;
 use storage_strategist_core::{
     build_diagnostics_bundle, build_scenario_plan, collect_doctor_info, compare_backends,
-    evaluate_suite_file, generate_recommendation_bundle, render_markdown_summary, run_scan, Report,
+    compare_reports as compare_saved_reports, evaluate_suite_file, generate_recommendation_bundle,
+    get_report as load_saved_report, import_report as import_saved_report,
+    list_reports as list_saved_reports, render_markdown_summary, run_scan, store_report, Report,
     ScanBackendKind, ScanOptions,
 };
 use tracing_subscriber::EnvFilter;
@@ -41,6 +43,8 @@ enum Commands {
     Plan(PlanArgs),
     /// Export diagnostics bundle (report + doctor + environment metadata).
     Diagnostics(DiagnosticsArgs),
+    /// Work with saved reports in the local report store.
+    Reports(ReportsArgs),
 }
 
 #[derive(Debug, Copy, Clone, ValueEnum)]
@@ -112,6 +116,14 @@ struct ScanArgs {
     /// Cache time-to-live in seconds when incremental cache is enabled.
     #[arg(long, default_value_t = 900, value_name = "SECONDS")]
     cache_ttl_seconds: u64,
+
+    /// Persist scan history metadata for trend analysis.
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    record_history: bool,
+
+    /// Optional local report store root directory.
+    #[arg(long, value_name = "DIR")]
+    report_store_dir: Option<PathBuf>,
 
     /// Forward-compatible no-op in v1 (read-only is always active).
     #[arg(long)]
@@ -204,6 +216,50 @@ struct DiagnosticsArgs {
     output: PathBuf,
 }
 
+#[derive(Debug, Args)]
+struct ReportsArgs {
+    /// Optional local report store root directory.
+    #[arg(long, value_name = "DIR")]
+    store_dir: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: ReportsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ReportsCommand {
+    /// List indexed reports from the local report store.
+    List,
+    /// Import an existing report JSON into the local report store.
+    Import(ReportsImportArgs),
+    /// Show a stored report by scan id.
+    Show(ReportsShowArgs),
+    /// Compare two stored reports by scan id.
+    Diff(ReportsDiffArgs),
+}
+
+#[derive(Debug, Args)]
+struct ReportsImportArgs {
+    #[arg(long, value_name = "FILE")]
+    path: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct ReportsShowArgs {
+    #[arg(long, value_name = "SCAN_ID")]
+    scan_id: String,
+}
+
+#[derive(Debug, Args)]
+struct ReportsDiffArgs {
+    #[arg(long, value_name = "LEFT_SCAN_ID")]
+    left: String,
+    #[arg(long, value_name = "RIGHT_SCAN_ID")]
+    right: String,
+    #[arg(long, value_name = "FILE")]
+    output: Option<PathBuf>,
+}
+
 #[derive(Debug, Serialize)]
 struct BenchmarkResult {
     iterations: usize,
@@ -230,6 +286,7 @@ fn main() -> Result<()> {
         Commands::Parity(args) => run_parity_command(args),
         Commands::Plan(args) => run_plan_command(args),
         Commands::Diagnostics(args) => run_diagnostics_command(args),
+        Commands::Reports(args) => run_reports_command(args),
     }
 }
 
@@ -247,6 +304,8 @@ fn run_scan_command(args: ScanArgs) -> Result<()> {
         incremental_cache,
         cache_dir,
         cache_ttl_seconds,
+        record_history,
+        report_store_dir,
         dry_run,
     } = args;
 
@@ -262,6 +321,8 @@ fn run_scan_command(args: ScanArgs) -> Result<()> {
         incremental_cache,
         cache_dir,
         cache_ttl_seconds,
+        record_history,
+        report_store_dir: report_store_dir.clone(),
         dry_run: true,
         ..ScanOptions::default()
     };
@@ -270,8 +331,13 @@ fn run_scan_command(args: ScanArgs) -> Result<()> {
     let payload = serde_json::to_string_pretty(&report).context("failed to serialize report")?;
     fs::write(&output, payload)
         .with_context(|| format!("failed to write report to {}", output.display()))?;
+    let stored_summary = store_report(&report, report_store_dir.as_deref(), Some(&output), false)?;
 
     println!("Report written to {}", output.display());
+    println!(
+        "Stored report indexed at {}",
+        stored_summary.stored_report_path
+    );
     println!(
         "Scanned {} root(s), {} disk(s), {} file(s), {} warning(s).",
         report.scan.roots.len(),
@@ -390,6 +456,7 @@ fn run_benchmark_command(args: BenchmarkArgs) -> Result<()> {
             progress: false,
             min_ratio: None,
             dry_run: true,
+            record_history: false,
             ..ScanOptions::default()
         };
         let report = run_scan(&options)?;
@@ -447,6 +514,7 @@ fn run_parity_command(args: ParityArgs) -> Result<()> {
         progress: false,
         min_ratio: None,
         dry_run: true,
+        record_history: false,
         ..ScanOptions::default()
     };
 
@@ -538,6 +606,72 @@ fn run_diagnostics_command(args: DiagnosticsArgs) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn run_reports_command(args: ReportsArgs) -> Result<()> {
+    match args.command {
+        ReportsCommand::List => {
+            let reports = list_saved_reports(args.store_dir.as_deref())?;
+            if reports.is_empty() {
+                println!("No stored reports found.");
+                return Ok(());
+            }
+
+            for report in reports {
+                println!(
+                    "- {} | {} | roots={} | backend={:?} | warnings={} | recommendations={} | imported={} | path={}",
+                    report.scan_id,
+                    report.generated_at,
+                    report.roots.join(", "),
+                    report.backend,
+                    report.warnings_count,
+                    report.recommendation_count,
+                    report.imported,
+                    report.stored_report_path
+                );
+            }
+            Ok(())
+        }
+        ReportsCommand::Import(import_args) => {
+            let result = import_saved_report(&import_args.path, args.store_dir.as_deref())?;
+            println!(
+                "Imported report {} into {}",
+                result.summary.scan_id, result.summary.stored_report_path
+            );
+            Ok(())
+        }
+        ReportsCommand::Show(show_args) => {
+            let report = load_saved_report(&show_args.scan_id, args.store_dir.as_deref())?;
+            let payload =
+                serde_json::to_string_pretty(&report).context("failed to serialize report")?;
+            println!("{payload}");
+            Ok(())
+        }
+        ReportsCommand::Diff(diff_args) => {
+            let diff = compare_saved_reports(
+                &diff_args.left,
+                &diff_args.right,
+                args.store_dir.as_deref(),
+            )?;
+            println!(
+                "Diff {} -> {} | disk_changes={} path_changes={} duplicate_waste_delta={} recommendation_changes={}",
+                diff.left_scan_id,
+                diff.right_scan_id,
+                diff.disk_diffs.len(),
+                diff.path_diffs.len(),
+                diff.duplicate_wasted_bytes_delta,
+                diff.recommendation_changes.len()
+            );
+            if let Some(output) = diff_args.output {
+                let payload = serde_json::to_string_pretty(&diff)
+                    .context("failed to serialize report diff")?;
+                fs::write(&output, payload)
+                    .with_context(|| format!("failed to write diff output {}", output.display()))?;
+                println!("Diff JSON written to {}", output.display());
+            }
+            Ok(())
+        }
+    }
 }
 
 fn run_doctor_command() {

--- a/crates/core/src/analyzers/dev_artifacts.rs
+++ b/crates/core/src/analyzers/dev_artifacts.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::analyzers::{Analyzer, AnalyzerResult};
+use crate::analyzers::{Analyzer, AnalyzerContext, AnalyzerResult};
 use crate::model::{
     EstimatedImpact, Recommendation, Report, RiskLevel, RuleTrace, RuleTraceStatus,
 };
@@ -15,7 +15,7 @@ impl Analyzer for DevArtifactsAnalyzer {
         "dev_artifacts"
     }
 
-    fn analyze(&self, report: &Report) -> AnalyzerResult {
+    fn analyze(&self, report: &Report, _context: &AnalyzerContext) -> AnalyzerResult {
         let mut findings: HashMap<&str, (u64, Vec<String>)> = HashMap::new();
         let mut traces = Vec::new();
 
@@ -53,6 +53,8 @@ impl Analyzer for DevArtifactsAnalyzer {
                     policy_safe: true,
                     policy_rules_applied: vec![],
                     policy_rules_blocked: vec![],
+                    evidence: Vec::new(),
+                    next_steps: Vec::new(),
                     estimated_impact: EstimatedImpact {
                         space_saving_bytes: Some(*total_size),
                         performance: None,
@@ -79,6 +81,8 @@ impl Analyzer for DevArtifactsAnalyzer {
                     policy_safe: true,
                     policy_rules_applied: vec![],
                     policy_rules_blocked: vec![],
+                    evidence: Vec::new(),
+                    next_steps: Vec::new(),
                     estimated_impact: EstimatedImpact {
                         space_saving_bytes: Some(*total_size),
                         performance: None,

--- a/crates/core/src/analyzers/mod.rs
+++ b/crates/core/src/analyzers/mod.rs
@@ -1,13 +1,20 @@
+use std::path::PathBuf;
+
 use crate::model::{Recommendation, Report, RuleTrace};
 
 pub mod dev_artifacts;
 pub mod system_caches;
 pub mod trend_analyzer;
 
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzerContext {
+    pub report_store_dir: Option<PathBuf>,
+}
+
 /// A trait for application-specific or pattern-specific analysis.
 pub trait Analyzer {
     fn id(&self) -> &'static str;
-    fn analyze(&self, report: &Report) -> AnalyzerResult;
+    fn analyze(&self, report: &Report, context: &AnalyzerContext) -> AnalyzerResult;
 }
 
 /// The output of a single analyzer.
@@ -18,12 +25,15 @@ pub struct AnalyzerResult {
 }
 
 /// Runs all registered analyzers and returns their combined results.
-pub fn run_analyzers(report: &Report) -> Vec<AnalyzerResult> {
+pub fn run_analyzers(report: &Report, context: &AnalyzerContext) -> Vec<AnalyzerResult> {
     let analyzers: Vec<Box<dyn Analyzer>> = vec![
         Box::new(dev_artifacts::DevArtifactsAnalyzer),
         Box::new(system_caches::SystemCachesAnalyzer),
         Box::new(trend_analyzer::TrendAnalyzer),
     ];
 
-    analyzers.iter().map(|a| a.analyze(report)).collect()
+    analyzers
+        .iter()
+        .map(|analyzer| analyzer.analyze(report, context))
+        .collect()
 }

--- a/crates/core/src/analyzers/system_caches.rs
+++ b/crates/core/src/analyzers/system_caches.rs
@@ -1,4 +1,4 @@
-use crate::analyzers::{Analyzer, AnalyzerResult};
+use crate::analyzers::{Analyzer, AnalyzerContext, AnalyzerResult};
 use crate::model::{
     EstimatedImpact, Recommendation, Report, RiskLevel, RuleTrace, RuleTraceStatus,
 };
@@ -21,7 +21,7 @@ impl Analyzer for SystemCachesAnalyzer {
         "system_caches"
     }
 
-    fn analyze(&self, report: &Report) -> AnalyzerResult {
+    fn analyze(&self, report: &Report, _context: &AnalyzerContext) -> AnalyzerResult {
         let mut recommendations = Vec::new();
         let mut traces = Vec::new();
         let cache_targets = get_os_cache_targets();
@@ -73,6 +73,8 @@ impl Analyzer for SystemCachesAnalyzer {
                         policy_safe: true,
                         policy_rules_applied: vec![],
                         policy_rules_blocked: vec![],
+                        evidence: Vec::new(),
+                        next_steps: Vec::new(),
                         estimated_impact: EstimatedImpact {
                             space_saving_bytes: Some(*total_size),
                             performance: None,

--- a/crates/core/src/analyzers/trend_analyzer.rs
+++ b/crates/core/src/analyzers/trend_analyzer.rs
@@ -1,4 +1,4 @@
-use crate::analyzers::{Analyzer, AnalyzerResult};
+use crate::analyzers::{Analyzer, AnalyzerContext, AnalyzerResult};
 use crate::history;
 use crate::model::{
     EstimatedImpact, Recommendation, Report, RiskLevel, RuleTrace, RuleTraceStatus,
@@ -16,9 +16,9 @@ impl Analyzer for TrendAnalyzer {
         "trend_analyzer"
     }
 
-    fn analyze(&self, _report: &Report) -> AnalyzerResult {
+    fn analyze(&self, _report: &Report, context: &AnalyzerContext) -> AnalyzerResult {
         let mut result = AnalyzerResult::default();
-        let history = match history::load_history() {
+        let history = match history::load_history(context.report_store_dir.as_deref()) {
             Ok(h) => h,
             Err(e) => {
                 result.traces.push(RuleTrace {
@@ -113,6 +113,8 @@ fn analyze_disk_trends(
                     policy_safe: true,
                     policy_rules_applied: vec![],
                     policy_rules_blocked: vec![],
+                    evidence: Vec::new(),
+                    next_steps: Vec::new(),
                     estimated_impact: EstimatedImpact {
                         space_saving_bytes: None,
                         performance: None,
@@ -158,6 +160,8 @@ fn analyze_path_trends(
                         policy_safe: true,
                         policy_rules_applied: vec![],
                         policy_rules_blocked: vec![],
+                        evidence: Vec::new(),
+                        next_steps: Vec::new(),
                         estimated_impact: EstimatedImpact {
                             space_saving_bytes: None,
                             performance: None,

--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -1,21 +1,11 @@
 use crate::model::ScanHistory;
+use crate::reports::history_file_path;
 use anyhow::Result;
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
-const CACHE_DIR_NAME: &str = "storage-strategist-cache";
-const HISTORY_FILE_NAME: &str = "history.json";
-
-fn history_cache_dir() -> PathBuf {
-    std::env::temp_dir().join(CACHE_DIR_NAME)
-}
-
-fn history_file_path() -> PathBuf {
-    history_cache_dir().join(HISTORY_FILE_NAME)
-}
-
-pub fn load_history() -> Result<ScanHistory> {
-    let path = history_file_path();
+pub fn load_history(custom_dir: Option<&Path>) -> Result<ScanHistory> {
+    let path = history_file_path(custom_dir);
     if !path.exists() {
         return Ok(ScanHistory::default());
     }
@@ -25,8 +15,8 @@ pub fn load_history() -> Result<ScanHistory> {
     Ok(history)
 }
 
-pub fn save_history(history: &ScanHistory) -> Result<()> {
-    let path = history_file_path();
+pub fn save_history(history: &ScanHistory, custom_dir: Option<&Path>) -> Result<()> {
+    let path = history_file_path(custom_dir);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod model;
 pub mod planner;
 pub mod policy;
 pub mod recommend;
+pub mod reports;
 pub mod role;
 pub mod scan;
 
@@ -24,18 +25,24 @@ pub use eval::{
 };
 pub use markdown::render_markdown_summary;
 pub use model::{
-    BackendParity, Category, CategorySuggestion, DiskInfo, DiskKind, DiskRole, DiskRoleHint,
-    DiskStorageType, DuplicateGroup, DuplicateIntent, DuplicateIntentLabel, EstimatedImpact,
-    FileEntry, FileTypeSummary, LocalityClass, PathStats, PerformanceClass, PolicyAction,
-    PolicyDecision, Recommendation, Report, RiskLevel, RuleTrace, RuleTraceStatus, ScanBackendKind,
-    ScanMetadata, ScanMetrics, ScanPhase, ScanPhaseCount, ScanProgressEvent, ScanProgressSummary,
-    REPORT_VERSION,
+    BackendParity, Category, CategorySuggestion, DiskDiff, DiskInfo, DiskKind, DiskRole,
+    DiskRoleHint, DiskStorageType, DuplicateGroup, DuplicateIntent, DuplicateIntentLabel,
+    EstimatedImpact, FileEntry, FileTypeSummary, LocalityClass, PathDiff, PathStats,
+    PerformanceClass, PolicyAction, PolicyDecision, Recommendation, RecommendationChange,
+    RecommendationChangeKind, RecommendationEvidence, RecommendationEvidenceKind, Report,
+    ReportDiff, ReportImportResult, ReportSummary, RiskLevel, RuleTrace, RuleTraceStatus,
+    ScanBackendKind, ScanMetadata, ScanMetrics, ScanPhase, ScanPhaseCount, ScanProgressEvent,
+    ScanProgressSummary, REPORT_VERSION,
 };
 pub use planner::{
     build_scenario_plan, ScenarioPlan, ScenarioProjection, ScenarioRiskMix, ScenarioStrategy,
 };
 pub use recommend::{
     generate_recommendation_bundle, generate_recommendations, RecommendationBundle,
+};
+pub use reports::{
+    build_report_diff, compare_reports, default_report_store_dir, get_report, history_file_path,
+    import_report, list_reports, report_path_for_scan, resolve_report_store_dir, store_report,
 };
 pub use role::infer_disk_roles;
 pub use scan::{

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -382,8 +382,38 @@ pub struct Recommendation {
     pub policy_rules_applied: Vec<String>,
     #[serde(default)]
     pub policy_rules_blocked: Vec<String>,
+    #[serde(default)]
+    pub evidence: Vec<RecommendationEvidence>,
+    #[serde(default)]
+    pub next_steps: Vec<String>,
     pub estimated_impact: EstimatedImpact,
     pub risk_level: RiskLevel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecommendationEvidence {
+    #[serde(default)]
+    pub kind: RecommendationEvidenceKind,
+    pub label: String,
+    pub detail: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub mount_point: Option<String>,
+    #[serde(default)]
+    pub duplicate_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RecommendationEvidenceKind {
+    Disk,
+    Directory,
+    DuplicateGroup,
+    HistoryDelta,
+    Warning,
+    #[default]
+    Other,
 }
 
 fn default_recommendation_confidence() -> f32 {
@@ -472,4 +502,101 @@ pub struct PathSnapshot {
     pub root_path: String,
     pub total_size_bytes: u64,
     pub file_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReportSummary {
+    pub scan_id: String,
+    pub generated_at: String,
+    pub report_version: String,
+    #[serde(default)]
+    pub roots: Vec<String>,
+    #[serde(default)]
+    pub backend: ScanBackendKind,
+    #[serde(default)]
+    pub warnings_count: u64,
+    #[serde(default)]
+    pub recommendation_count: u64,
+    pub stored_report_path: String,
+    #[serde(default)]
+    pub source_path: Option<String>,
+    #[serde(default)]
+    pub imported: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReportImportResult {
+    pub summary: ReportSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReportDiff {
+    pub left_scan_id: String,
+    pub right_scan_id: String,
+    pub left_generated_at: String,
+    pub right_generated_at: String,
+    #[serde(default)]
+    pub duplicate_wasted_bytes_delta: i64,
+    #[serde(default)]
+    pub disk_diffs: Vec<DiskDiff>,
+    #[serde(default)]
+    pub path_diffs: Vec<PathDiff>,
+    #[serde(default)]
+    pub recommendation_changes: Vec<RecommendationChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DiskDiff {
+    pub mount_point: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub left_free_space_bytes: Option<u64>,
+    #[serde(default)]
+    pub right_free_space_bytes: Option<u64>,
+    pub free_space_delta_bytes: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PathDiff {
+    pub root_path: String,
+    #[serde(default)]
+    pub left_total_size_bytes: Option<u64>,
+    #[serde(default)]
+    pub right_total_size_bytes: Option<u64>,
+    pub total_size_delta_bytes: i64,
+    #[serde(default)]
+    pub left_file_count: Option<u64>,
+    #[serde(default)]
+    pub right_file_count: Option<u64>,
+    pub file_count_delta: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RecommendationChangeKind {
+    Added,
+    Removed,
+    ConfidenceChanged,
+    TargetChanged,
+    RiskChanged,
+    RationaleChanged,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecommendationChange {
+    pub id: String,
+    pub change: RecommendationChangeKind,
+    #[serde(default)]
+    pub left_confidence: Option<f32>,
+    #[serde(default)]
+    pub right_confidence: Option<f32>,
+    #[serde(default)]
+    pub left_target_mount: Option<String>,
+    #[serde(default)]
+    pub right_target_mount: Option<String>,
+    #[serde(default)]
+    pub left_risk_level: Option<RiskLevel>,
+    #[serde(default)]
+    pub right_risk_level: Option<RiskLevel>,
 }

--- a/crates/core/src/planner.rs
+++ b/crates/core/src/planner.rs
@@ -240,6 +240,8 @@ mod tests {
             policy_safe,
             policy_rules_applied: Vec::new(),
             policy_rules_blocked: Vec::new(),
+            evidence: Vec::new(),
+            next_steps: Vec::new(),
             estimated_impact: EstimatedImpact {
                 space_saving_bytes,
                 performance: None,

--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -265,6 +265,8 @@ mod tests {
             policy_safe: true,
             policy_rules_applied: Vec::new(),
             policy_rules_blocked: Vec::new(),
+            evidence: Vec::new(),
+            next_steps: Vec::new(),
             estimated_impact: EstimatedImpact {
                 space_saving_bytes: None,
                 performance: None,
@@ -351,6 +353,8 @@ mod tests {
             policy_safe: true,
             policy_rules_applied: Vec::new(),
             policy_rules_blocked: Vec::new(),
+            evidence: Vec::new(),
+            next_steps: Vec::new(),
             estimated_impact: EstimatedImpact {
                 space_saving_bytes: None,
                 performance: None,

--- a/crates/core/src/recommend.rs
+++ b/crates/core/src/recommend.rs
@@ -3,9 +3,11 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::analyzers::{run_analyzers, AnalyzerContext};
 use crate::model::{
     Category, DiskInfo, DiskStorageType, DuplicateIntentLabel, EstimatedImpact, LocalityClass,
-    PerformanceClass, Recommendation, Report, RiskLevel, RuleTrace, RuleTraceStatus,
+    PerformanceClass, Recommendation, RecommendationEvidence, RecommendationEvidenceKind, Report,
+    RiskLevel, RuleTrace, RuleTraceStatus,
 };
 use crate::policy::enforce_recommendation_policies;
 
@@ -25,6 +27,13 @@ pub fn generate_recommendations(report: &Report) -> Vec<Recommendation> {
 }
 
 pub fn generate_recommendation_bundle(report: &Report) -> RecommendationBundle {
+    generate_recommendation_bundle_with_context(report, &AnalyzerContext::default())
+}
+
+pub fn generate_recommendation_bundle_with_context(
+    report: &Report,
+    analyzer_context: &AnalyzerContext,
+) -> RecommendationBundle {
     let disk_scores = category_scores_by_disk(report);
     let mut candidates = Vec::new();
     let mut traces = Vec::new();
@@ -71,16 +80,212 @@ pub fn generate_recommendation_bundle(report: &Report) -> RecommendationBundle {
         &mut candidates,
         &mut traces,
     );
+    for result in run_analyzers(report, analyzer_context) {
+        candidates.extend(result.recommendations);
+        traces.extend(result.traces);
+    }
 
     let policy_outcome = enforce_recommendation_policies(report, candidates);
     traces.extend(policy_outcome.rejection_traces);
+    let mut recommendations = policy_outcome.recommendations;
+    enrich_recommendations(report, &mut recommendations);
 
     RecommendationBundle {
-        recommendations: policy_outcome.recommendations,
+        recommendations,
         rule_traces: traces,
         policy_decisions: policy_outcome.decisions,
         contradiction_count: policy_outcome.contradiction_count,
     }
+}
+
+fn enrich_recommendations(report: &Report, recommendations: &mut [Recommendation]) {
+    for recommendation in recommendations {
+        if recommendation.evidence.is_empty() {
+            recommendation.evidence = gather_recommendation_evidence(report, recommendation);
+        }
+        if recommendation.next_steps.is_empty() {
+            recommendation.next_steps = recommendation_next_steps(recommendation);
+        }
+    }
+}
+
+fn gather_recommendation_evidence(
+    report: &Report,
+    recommendation: &Recommendation,
+) -> Vec<RecommendationEvidence> {
+    let mut evidence = Vec::new();
+
+    if let Some(target_mount) = &recommendation.target_mount {
+        if let Some(disk) = report
+            .disks
+            .iter()
+            .find(|disk| &disk.mount_point == target_mount)
+        {
+            evidence.push(RecommendationEvidence {
+                kind: RecommendationEvidenceKind::Disk,
+                label: "Target disk".to_string(),
+                detail: format!(
+                    "{} | role {:?} | locality {:?} | perf {:?}",
+                    disk.name, disk.role_hint.role, disk.locality_class, disk.performance_class
+                ),
+                path: None,
+                mount_point: Some(disk.mount_point.clone()),
+                duplicate_hash: None,
+            });
+        }
+    }
+
+    if recommendation.id.contains("duplicate") {
+        if let Some(group) = report
+            .duplicates
+            .iter()
+            .filter(|group| group.intent.label == DuplicateIntentLabel::LikelyRedundant)
+            .max_by_key(|group| group.total_wasted_bytes)
+        {
+            evidence.push(RecommendationEvidence {
+                kind: RecommendationEvidenceKind::DuplicateGroup,
+                label: "Largest redundant duplicate group".to_string(),
+                detail: format!(
+                    "{} file(s), wasted {} bytes",
+                    group.files.len(),
+                    group.total_wasted_bytes
+                ),
+                path: group.files.first().map(|file| file.path.clone()),
+                mount_point: group.files.first().and_then(|file| file.disk_mount.clone()),
+                duplicate_hash: Some(group.hash.clone()),
+            });
+        }
+    }
+
+    if recommendation.id.starts_with("cleanup-") {
+        if let Some(directory) = report
+            .paths
+            .iter()
+            .flat_map(|path| path.largest_directories.iter())
+            .max_by_key(|directory| directory.size_bytes)
+        {
+            evidence.push(RecommendationEvidence {
+                kind: RecommendationEvidenceKind::Directory,
+                label: "Largest matching directory".to_string(),
+                detail: format!("{} bytes", directory.size_bytes),
+                path: Some(directory.path.clone()),
+                mount_point: None,
+                duplicate_hash: None,
+            });
+        }
+    }
+
+    if recommendation.id.starts_with("disk-growth-")
+        || recommendation.id.starts_with("path-growth-")
+    {
+        evidence.push(RecommendationEvidence {
+            kind: RecommendationEvidenceKind::HistoryDelta,
+            label: "Historical change".to_string(),
+            detail: recommendation.rationale.clone(),
+            path: None,
+            mount_point: recommendation.target_mount.clone(),
+            duplicate_hash: None,
+        });
+    }
+
+    if recommendation.id.contains("cloud") {
+        for disk in report
+            .disks
+            .iter()
+            .filter(|disk| !disk.eligible_for_local_target)
+            .take(2)
+        {
+            evidence.push(RecommendationEvidence {
+                kind: RecommendationEvidenceKind::Disk,
+                label: "Excluded destination".to_string(),
+                detail: disk.ineligible_reasons.join(" | "),
+                path: None,
+                mount_point: Some(disk.mount_point.clone()),
+                duplicate_hash: None,
+            });
+        }
+    }
+
+    if let Some(path_stats) = report
+        .paths
+        .iter()
+        .find(|path| recommendation.target_mount.as_ref() == path.disk_mount.as_ref())
+    {
+        if let Some(directory) = path_stats.largest_directories.first() {
+            evidence.push(RecommendationEvidence {
+                kind: RecommendationEvidenceKind::Directory,
+                label: "Largest scanned directory on related root".to_string(),
+                detail: format!("{} bytes", directory.size_bytes),
+                path: Some(directory.path.clone()),
+                mount_point: path_stats.disk_mount.clone(),
+                duplicate_hash: None,
+            });
+        }
+    }
+
+    for warning in report.warnings.iter().take(1) {
+        evidence.push(RecommendationEvidence {
+            kind: RecommendationEvidenceKind::Warning,
+            label: "Scan warning".to_string(),
+            detail: warning.clone(),
+            path: None,
+            mount_point: None,
+            duplicate_hash: None,
+        });
+    }
+
+    if evidence.is_empty() {
+        evidence.push(RecommendationEvidence {
+            kind: RecommendationEvidenceKind::Other,
+            label: "Rule rationale".to_string(),
+            detail: recommendation.rationale.clone(),
+            path: None,
+            mount_point: recommendation.target_mount.clone(),
+            duplicate_hash: None,
+        });
+    }
+
+    evidence
+}
+
+fn recommendation_next_steps(recommendation: &Recommendation) -> Vec<String> {
+    if recommendation.id == "active-workload-placement" {
+        return vec![
+            "Confirm the target disk has enough free space for active workloads.".to_string(),
+            "Review the suggested move manually before changing any library paths.".to_string(),
+        ];
+    }
+
+    if recommendation.id == "backup-gap" {
+        return vec![
+            "Verify there is a second local or offline copy of the library.".to_string(),
+            "Prefer backup/archive targets over active-use disks when adding redundancy."
+                .to_string(),
+        ];
+    }
+
+    if recommendation.id.contains("duplicate") {
+        return vec![
+            "Inspect the duplicate group and keep the authoritative copy first.".to_string(),
+            "Use the diagnostics bundle if you need to review the full context before cleanup."
+                .to_string(),
+        ];
+    }
+
+    if recommendation.id.starts_with("cleanup-") {
+        return vec![
+            "Inspect the evidence paths and estimate the reclaimable space before cleanup."
+                .to_string(),
+            "Use tool-native cleanup commands where possible instead of manual deletion."
+                .to_string(),
+        ];
+    }
+
+    vec![
+        "Review the linked evidence before taking action.".to_string(),
+        "Export diagnostics if you want to compare or share the recommendation context."
+            .to_string(),
+    ]
 }
 
 fn emit_optional(
@@ -191,6 +396,8 @@ fn active_workload_placement_rule(
         policy_safe: true,
         policy_rules_applied: vec!["safe_target_policy".to_string()],
         policy_rules_blocked: Vec::new(),
+        evidence: Vec::new(),
+        next_steps: Vec::new(),
         estimated_impact: EstimatedImpact {
             space_saving_bytes: None,
             performance: Some(
@@ -285,6 +492,8 @@ fn consolidation_rule(report: &Report) -> Option<Recommendation> {
         policy_safe: true,
         policy_rules_applied: vec!["safe_target_policy".to_string()],
         policy_rules_blocked: Vec::new(),
+        evidence: Vec::new(),
+        next_steps: Vec::new(),
         estimated_impact: EstimatedImpact {
             space_saving_bytes: Some(source_used),
             performance: Some("Potentially fewer active local disks to manage.".to_string()),
@@ -336,6 +545,8 @@ fn risky_disk_rule(
             policy_safe: true,
             policy_rules_applied: vec!["safe_target_policy".to_string()],
             policy_rules_blocked: Vec::new(),
+            evidence: Vec::new(),
+            next_steps: Vec::new(),
             estimated_impact: EstimatedImpact {
                 space_saving_bytes: None,
                 performance: Some(
@@ -394,6 +605,8 @@ fn backup_gap_rule(
             policy_safe: true,
             policy_rules_applied: vec!["safe_target_policy".to_string()],
             policy_rules_blocked: Vec::new(),
+            evidence: Vec::new(),
+            next_steps: Vec::new(),
             estimated_impact: EstimatedImpact {
                 space_saving_bytes: None,
                 performance: None,
@@ -445,6 +658,8 @@ fn duplicate_cleanup_rule(report: &Report) -> Option<Recommendation> {
         policy_safe: true,
         policy_rules_applied: vec!["safe_target_policy".to_string()],
         policy_rules_blocked: Vec::new(),
+        evidence: Vec::new(),
+        next_steps: Vec::new(),
         estimated_impact: EstimatedImpact {
             space_saving_bytes: Some(total_wasted),
             performance: Some("Potential capacity relief and reduced indexing load.".to_string()),
@@ -484,6 +699,8 @@ fn os_headroom_rule(
         policy_safe: true,
         policy_rules_applied: vec!["safe_target_policy".to_string()],
         policy_rules_blocked: Vec::new(),
+        evidence: Vec::new(),
+        next_steps: Vec::new(),
         estimated_impact: EstimatedImpact {
             space_saving_bytes: None,
             performance: Some(
@@ -525,6 +742,8 @@ fn cloud_exclusion_notice_rule(report: &Report) -> Option<Recommendation> {
         policy_safe: true,
         policy_rules_applied: vec!["safe_target_policy".to_string()],
         policy_rules_blocked: Vec::new(),
+        evidence: Vec::new(),
+        next_steps: Vec::new(),
         estimated_impact: EstimatedImpact {
             space_saving_bytes: None,
             performance: None,

--- a/crates/core/src/reports.rs
+++ b/crates/core/src/reports.rs
@@ -1,0 +1,583 @@
+use std::collections::{BTreeSet, HashMap};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::model::{
+    DiskDiff, PathDiff, Recommendation, RecommendationChange, RecommendationChangeKind, Report,
+    ReportDiff, ReportImportResult, ReportSummary,
+};
+
+const APP_DIR_NAME: &str = "storage-strategist";
+const STORE_DIR_NAME: &str = "report-store";
+const REPORTS_DIR_NAME: &str = "reports";
+const INDEX_FILE_NAME: &str = "index.json";
+const HISTORY_FILE_NAME: &str = "history.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct ReportIndex {
+    #[serde(default)]
+    reports: Vec<ReportSummary>,
+}
+
+pub fn default_report_store_dir() -> PathBuf {
+    if cfg!(target_os = "windows") {
+        env::var_os("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .unwrap_or_else(env::temp_dir)
+            .join(APP_DIR_NAME)
+            .join(STORE_DIR_NAME)
+    } else if let Some(state_home) = env::var_os("XDG_STATE_HOME") {
+        PathBuf::from(state_home)
+            .join(APP_DIR_NAME)
+            .join(STORE_DIR_NAME)
+    } else if let Some(home) = env::var_os("HOME") {
+        PathBuf::from(home)
+            .join(".local")
+            .join("state")
+            .join(APP_DIR_NAME)
+            .join(STORE_DIR_NAME)
+    } else {
+        env::temp_dir().join(APP_DIR_NAME).join(STORE_DIR_NAME)
+    }
+}
+
+pub fn resolve_report_store_dir(custom_dir: Option<&Path>) -> PathBuf {
+    custom_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(default_report_store_dir)
+}
+
+pub fn history_file_path(custom_dir: Option<&Path>) -> PathBuf {
+    resolve_report_store_dir(custom_dir).join(HISTORY_FILE_NAME)
+}
+
+pub fn report_path_for_scan(scan_id: &str, custom_dir: Option<&Path>) -> PathBuf {
+    reports_dir(custom_dir).join(format!("{scan_id}.json"))
+}
+
+pub fn list_reports(custom_dir: Option<&Path>) -> Result<Vec<ReportSummary>> {
+    let mut index = load_index(custom_dir)?;
+    let changed = cleanup_orphaned_entries(&mut index);
+    sort_reports(&mut index.reports);
+    if changed {
+        save_index(custom_dir, &index)?;
+    }
+    Ok(index.reports)
+}
+
+pub fn store_report(
+    report: &Report,
+    custom_dir: Option<&Path>,
+    source_path: Option<&Path>,
+    imported: bool,
+) -> Result<ReportSummary> {
+    ensure_store_layout(custom_dir)?;
+
+    let stored_report_path = report_path_for_scan(&report.scan_id, custom_dir);
+    let payload = serde_json::to_string_pretty(report).context("failed to serialize report")?;
+    fs::write(&stored_report_path, payload).with_context(|| {
+        format!(
+            "failed to write stored report {}",
+            stored_report_path.display()
+        )
+    })?;
+
+    let mut index = load_index(custom_dir)?;
+    cleanup_orphaned_entries(&mut index);
+
+    let summary = build_summary(report, &stored_report_path, source_path, imported);
+    index
+        .reports
+        .retain(|entry| entry.scan_id != summary.scan_id);
+    index.reports.push(summary.clone());
+    sort_reports(&mut index.reports);
+    save_index(custom_dir, &index)?;
+
+    Ok(summary)
+}
+
+pub fn import_report(
+    path: impl AsRef<Path>,
+    custom_dir: Option<&Path>,
+) -> Result<ReportImportResult> {
+    let source_path = path.as_ref();
+    let payload = fs::read_to_string(source_path)
+        .with_context(|| format!("failed to read report {}", source_path.display()))?;
+    let report: Report = serde_json::from_str(&payload)
+        .with_context(|| format!("failed to parse {}", source_path.display()))?;
+    let summary = store_report(&report, custom_dir, Some(source_path), true)?;
+    Ok(ReportImportResult { summary })
+}
+
+pub fn get_report(scan_id: &str, custom_dir: Option<&Path>) -> Result<Report> {
+    let path = report_path_for_scan(scan_id, custom_dir);
+    let payload = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read stored report {}", path.display()))?;
+    let report: Report = serde_json::from_str(&payload)
+        .with_context(|| format!("failed to parse stored report {}", path.display()))?;
+    Ok(report)
+}
+
+pub fn compare_reports(
+    left_scan_id: &str,
+    right_scan_id: &str,
+    custom_dir: Option<&Path>,
+) -> Result<ReportDiff> {
+    let left = get_report(left_scan_id, custom_dir)?;
+    let right = get_report(right_scan_id, custom_dir)?;
+    Ok(build_report_diff(&left, &right))
+}
+
+pub fn build_report_diff(left: &Report, right: &Report) -> ReportDiff {
+    ReportDiff {
+        left_scan_id: left.scan_id.clone(),
+        right_scan_id: right.scan_id.clone(),
+        left_generated_at: left.generated_at.clone(),
+        right_generated_at: right.generated_at.clone(),
+        duplicate_wasted_bytes_delta: signed_delta(
+            Some(total_duplicate_waste(left)),
+            Some(total_duplicate_waste(right)),
+        ),
+        disk_diffs: build_disk_diffs(left, right),
+        path_diffs: build_path_diffs(left, right),
+        recommendation_changes: build_recommendation_changes(left, right),
+    }
+}
+
+fn build_disk_diffs(left: &Report, right: &Report) -> Vec<DiskDiff> {
+    let left_by_mount = left
+        .disks
+        .iter()
+        .map(|disk| (disk.mount_point.clone(), disk))
+        .collect::<HashMap<_, _>>();
+    let right_by_mount = right
+        .disks
+        .iter()
+        .map(|disk| (disk.mount_point.clone(), disk))
+        .collect::<HashMap<_, _>>();
+
+    let mounts = left_by_mount
+        .keys()
+        .chain(right_by_mount.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    mounts
+        .into_iter()
+        .filter_map(|mount_point| {
+            let left_disk = left_by_mount.get(&mount_point);
+            let right_disk = right_by_mount.get(&mount_point);
+            let delta = signed_delta(
+                left_disk.map(|disk| disk.free_space_bytes),
+                right_disk.map(|disk| disk.free_space_bytes),
+            );
+
+            if delta == 0 && left_disk.is_some() == right_disk.is_some() {
+                return None;
+            }
+
+            Some(DiskDiff {
+                mount_point,
+                name: right_disk.or(left_disk).map(|disk| disk.name.clone()),
+                left_free_space_bytes: left_disk.map(|disk| disk.free_space_bytes),
+                right_free_space_bytes: right_disk.map(|disk| disk.free_space_bytes),
+                free_space_delta_bytes: delta,
+            })
+        })
+        .collect()
+}
+
+fn build_path_diffs(left: &Report, right: &Report) -> Vec<PathDiff> {
+    let left_by_root = left
+        .paths
+        .iter()
+        .map(|path| (path.root_path.clone(), path))
+        .collect::<HashMap<_, _>>();
+    let right_by_root = right
+        .paths
+        .iter()
+        .map(|path| (path.root_path.clone(), path))
+        .collect::<HashMap<_, _>>();
+
+    let roots = left_by_root
+        .keys()
+        .chain(right_by_root.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    roots
+        .into_iter()
+        .filter_map(|root_path| {
+            let left_path = left_by_root.get(&root_path);
+            let right_path = right_by_root.get(&root_path);
+            let bytes_delta = signed_delta(
+                left_path.map(|path| path.total_size_bytes),
+                right_path.map(|path| path.total_size_bytes),
+            );
+            let file_count_delta = signed_delta(
+                left_path.map(|path| path.file_count),
+                right_path.map(|path| path.file_count),
+            );
+
+            if bytes_delta == 0
+                && file_count_delta == 0
+                && left_path.is_some() == right_path.is_some()
+            {
+                return None;
+            }
+
+            Some(PathDiff {
+                root_path,
+                left_total_size_bytes: left_path.map(|path| path.total_size_bytes),
+                right_total_size_bytes: right_path.map(|path| path.total_size_bytes),
+                total_size_delta_bytes: bytes_delta,
+                left_file_count: left_path.map(|path| path.file_count),
+                right_file_count: right_path.map(|path| path.file_count),
+                file_count_delta,
+            })
+        })
+        .collect()
+}
+
+fn build_recommendation_changes(left: &Report, right: &Report) -> Vec<RecommendationChange> {
+    let left_by_id = left
+        .recommendations
+        .iter()
+        .map(|recommendation| (recommendation.id.clone(), recommendation))
+        .collect::<HashMap<_, _>>();
+    let right_by_id = right
+        .recommendations
+        .iter()
+        .map(|recommendation| (recommendation.id.clone(), recommendation))
+        .collect::<HashMap<_, _>>();
+
+    let ids = left_by_id
+        .keys()
+        .chain(right_by_id.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut changes = Vec::new();
+    for id in ids {
+        let left_rec = left_by_id.get(&id).copied();
+        let right_rec = right_by_id.get(&id).copied();
+
+        match (left_rec, right_rec) {
+            (None, Some(right_rec)) => changes.push(change_entry(
+                &id,
+                RecommendationChangeKind::Added,
+                None,
+                Some(right_rec),
+            )),
+            (Some(left_rec), None) => changes.push(change_entry(
+                &id,
+                RecommendationChangeKind::Removed,
+                Some(left_rec),
+                None,
+            )),
+            (Some(left_rec), Some(right_rec)) => {
+                if (left_rec.confidence - right_rec.confidence).abs() > 0.001 {
+                    changes.push(change_entry(
+                        &id,
+                        RecommendationChangeKind::ConfidenceChanged,
+                        Some(left_rec),
+                        Some(right_rec),
+                    ));
+                }
+                if left_rec.target_mount != right_rec.target_mount {
+                    changes.push(change_entry(
+                        &id,
+                        RecommendationChangeKind::TargetChanged,
+                        Some(left_rec),
+                        Some(right_rec),
+                    ));
+                }
+                if left_rec.risk_level != right_rec.risk_level {
+                    changes.push(change_entry(
+                        &id,
+                        RecommendationChangeKind::RiskChanged,
+                        Some(left_rec),
+                        Some(right_rec),
+                    ));
+                }
+                if left_rec.rationale != right_rec.rationale {
+                    changes.push(change_entry(
+                        &id,
+                        RecommendationChangeKind::RationaleChanged,
+                        Some(left_rec),
+                        Some(right_rec),
+                    ));
+                }
+            }
+            (None, None) => {}
+        }
+    }
+
+    changes
+}
+
+fn change_entry(
+    id: &str,
+    change: RecommendationChangeKind,
+    left: Option<&Recommendation>,
+    right: Option<&Recommendation>,
+) -> RecommendationChange {
+    RecommendationChange {
+        id: id.to_string(),
+        change,
+        left_confidence: left.map(|recommendation| recommendation.confidence),
+        right_confidence: right.map(|recommendation| recommendation.confidence),
+        left_target_mount: left.and_then(|recommendation| recommendation.target_mount.clone()),
+        right_target_mount: right.and_then(|recommendation| recommendation.target_mount.clone()),
+        left_risk_level: left.map(|recommendation| recommendation.risk_level.clone()),
+        right_risk_level: right.map(|recommendation| recommendation.risk_level.clone()),
+    }
+}
+
+fn build_summary(
+    report: &Report,
+    stored_report_path: &Path,
+    source_path: Option<&Path>,
+    imported: bool,
+) -> ReportSummary {
+    ReportSummary {
+        scan_id: report.scan_id.clone(),
+        generated_at: report.generated_at.clone(),
+        report_version: report.report_version.clone(),
+        roots: report.scan.roots.clone(),
+        backend: report.scan.backend.clone(),
+        warnings_count: report.warnings.len() as u64,
+        recommendation_count: report.recommendations.len() as u64,
+        stored_report_path: stored_report_path.to_string_lossy().to_string(),
+        source_path: source_path.map(|path| path.to_string_lossy().to_string()),
+        imported,
+    }
+}
+
+fn ensure_store_layout(custom_dir: Option<&Path>) -> Result<()> {
+    let root = resolve_report_store_dir(custom_dir);
+    fs::create_dir_all(root.join(REPORTS_DIR_NAME)).with_context(|| {
+        format!(
+            "failed to create report store {}",
+            root.join(REPORTS_DIR_NAME).display()
+        )
+    })?;
+    Ok(())
+}
+
+fn reports_dir(custom_dir: Option<&Path>) -> PathBuf {
+    resolve_report_store_dir(custom_dir).join(REPORTS_DIR_NAME)
+}
+
+fn index_file_path(custom_dir: Option<&Path>) -> PathBuf {
+    resolve_report_store_dir(custom_dir).join(INDEX_FILE_NAME)
+}
+
+fn load_index(custom_dir: Option<&Path>) -> Result<ReportIndex> {
+    let path = index_file_path(custom_dir);
+    if !path.exists() {
+        return Ok(ReportIndex::default());
+    }
+
+    let payload = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read report index {}", path.display()))?;
+    let index = serde_json::from_str(&payload)
+        .with_context(|| format!("failed to parse report index {}", path.display()))?;
+    Ok(index)
+}
+
+fn save_index(custom_dir: Option<&Path>, index: &ReportIndex) -> Result<()> {
+    ensure_store_layout(custom_dir)?;
+    let path = index_file_path(custom_dir);
+    let payload =
+        serde_json::to_string_pretty(index).context("failed to serialize report index payload")?;
+    fs::write(&path, payload)
+        .with_context(|| format!("failed to write report index {}", path.display()))?;
+    Ok(())
+}
+
+fn cleanup_orphaned_entries(index: &mut ReportIndex) -> bool {
+    let before = index.reports.len();
+    index
+        .reports
+        .retain(|entry| Path::new(&entry.stored_report_path).exists());
+    before != index.reports.len()
+}
+
+fn sort_reports(reports: &mut [ReportSummary]) {
+    reports.sort_by(|left, right| right.generated_at.cmp(&left.generated_at));
+}
+
+fn total_duplicate_waste(report: &Report) -> u64 {
+    report
+        .duplicates
+        .iter()
+        .map(|duplicate_group| duplicate_group.total_wasted_bytes)
+        .sum()
+}
+
+fn signed_delta(left: Option<u64>, right: Option<u64>) -> i64 {
+    let left = left.unwrap_or(0) as i128;
+    let right = right.unwrap_or(0) as i128;
+    let delta = right - left;
+    delta.try_into().unwrap_or(if delta.is_negative() {
+        i64::MIN
+    } else {
+        i64::MAX
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_report_diff, store_report};
+    use crate::model::{
+        EstimatedImpact, Recommendation, RecommendationEvidence, RecommendationEvidenceKind,
+        Report, RiskLevel, ScanBackendKind, ScanMetadata, ScanMetrics,
+    };
+    use tempfile::tempdir;
+
+    #[test]
+    fn stores_report_and_indexes_summary() {
+        let dir = tempdir().expect("temp dir");
+        let report = sample_report("scan-1", 100, 1);
+
+        let summary = store_report(&report, Some(dir.path()), None, false).expect("stored report");
+
+        assert_eq!(summary.scan_id, "scan-1");
+        assert!(dir.path().join("reports").join("scan-1.json").exists());
+    }
+
+    #[test]
+    fn diff_reports_tracks_space_and_recommendation_changes() {
+        let left = sample_report("scan-1", 100, 1);
+        let right = sample_report("scan-2", 60, 2);
+
+        let diff = build_report_diff(&left, &right);
+
+        assert_eq!(diff.disk_diffs.len(), 1);
+        assert_eq!(diff.path_diffs.len(), 1);
+        assert_eq!(diff.recommendation_changes.len(), 1);
+        assert!(diff.duplicate_wasted_bytes_delta > 0);
+    }
+
+    fn sample_report(
+        scan_id: &str,
+        free_space_bytes: u64,
+        recommendation_confidence: u64,
+    ) -> Report {
+        Report {
+            report_version: "1.3.0".to_string(),
+            generated_at: format!("{scan_id}-generated"),
+            scan_id: scan_id.to_string(),
+            scan: ScanMetadata {
+                roots: vec!["D:\\".to_string()],
+                max_depth: None,
+                excludes: Vec::new(),
+                dedupe: false,
+                dedupe_min_size: 0,
+                dry_run: true,
+                backend: ScanBackendKind::Native,
+                progress: false,
+                min_ratio: None,
+                emit_progress_events: false,
+                progress_interval_ms: 250,
+            },
+            scan_metrics: ScanMetrics::default(),
+            scan_progress_summary: Default::default(),
+            backend_parity: None,
+            disks: vec![crate::model::DiskInfo {
+                name: "Disk".to_string(),
+                mount_point: "D:\\".to_string(),
+                total_space_bytes: 200,
+                free_space_bytes,
+                disk_kind: crate::model::DiskKind::Ssd,
+                file_system: Some("ntfs".to_string()),
+                storage_type: Default::default(),
+                locality_class: Default::default(),
+                locality_confidence: 1.0,
+                locality_rationale: "fixture".to_string(),
+                is_os_drive: false,
+                is_removable: false,
+                vendor: None,
+                model: None,
+                interface: None,
+                rotational: None,
+                hybrid: None,
+                performance_class: Default::default(),
+                performance_confidence: 1.0,
+                performance_rationale: "fixture".to_string(),
+                eligible_for_local_target: true,
+                ineligible_reasons: Vec::new(),
+                metadata_notes: Vec::new(),
+                role_hint: Default::default(),
+                target_role_eligibility: Vec::new(),
+            }],
+            paths: vec![crate::model::PathStats {
+                root_path: "D:\\Games".to_string(),
+                disk_mount: Some("D:\\".to_string()),
+                total_size_bytes: 100 + recommendation_confidence,
+                file_count: 10 + recommendation_confidence,
+                directory_count: 3,
+                largest_files: crate::model::LargestFiles {
+                    entries: Vec::new(),
+                },
+                largest_directories: Vec::new(),
+                file_type_summary: crate::model::FileTypeSummary {
+                    top_extensions: Vec::new(),
+                    other_files: 0,
+                    other_bytes: 0,
+                    total_files: 0,
+                    total_bytes: 0,
+                },
+                activity: crate::model::ActivitySignals {
+                    recent_files: 0,
+                    stale_files: 0,
+                    unknown_modified_files: 0,
+                },
+            }],
+            categories: Vec::new(),
+            duplicates: vec![crate::model::DuplicateGroup {
+                size_bytes: 10,
+                hash: "hash-1".to_string(),
+                files: Vec::new(),
+                total_wasted_bytes: 5 + recommendation_confidence,
+                intent: crate::model::DuplicateIntent {
+                    label: crate::model::DuplicateIntentLabel::LikelyRedundant,
+                    rationale: "fixture".to_string(),
+                },
+            }],
+            recommendations: vec![Recommendation {
+                id: "rec-1".to_string(),
+                title: "Recommendation".to_string(),
+                rationale: "Fixture recommendation".to_string(),
+                confidence: recommendation_confidence as f32,
+                target_mount: Some("D:\\".to_string()),
+                policy_safe: true,
+                policy_rules_applied: vec!["safe_target_policy".to_string()],
+                policy_rules_blocked: Vec::new(),
+                evidence: vec![RecommendationEvidence {
+                    kind: RecommendationEvidenceKind::Disk,
+                    label: "Target disk".to_string(),
+                    detail: "Fixture evidence".to_string(),
+                    path: None,
+                    mount_point: Some("D:\\".to_string()),
+                    duplicate_hash: None,
+                }],
+                next_steps: vec!["Review disk usage".to_string()],
+                estimated_impact: EstimatedImpact {
+                    space_saving_bytes: Some(10),
+                    performance: None,
+                    risk_notes: None,
+                },
+                risk_level: RiskLevel::Low,
+            }],
+            policy_decisions: Vec::new(),
+            rule_traces: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+}

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -16,7 +16,7 @@ use tracing::info;
 use uuid::Uuid;
 use walkdir::WalkDir;
 
-use crate::analyzers;
+use crate::analyzers::AnalyzerContext;
 use crate::categorize::{aggregate_categories_by_disk, categorize_disks, categorize_paths};
 use crate::dedupe::{find_duplicates, FileRecord};
 use crate::device::{enrich_disks, DiskProbe};
@@ -26,7 +26,7 @@ use crate::model::{
     FileTypeSummary, LargestFiles, PathStats, Report, ScanBackendKind, ScanMetadata, ScanMetrics,
     ScanPhase, ScanPhaseCount, ScanProgressEvent, ScanProgressSummary, REPORT_VERSION,
 };
-use crate::recommend::generate_recommendation_bundle;
+use crate::recommend::generate_recommendation_bundle_with_context;
 use crate::role::infer_disk_roles;
 
 #[cfg(feature = "pdu-backend")]
@@ -66,6 +66,8 @@ pub struct ScanOptions {
     pub incremental_cache: bool,
     pub cache_dir: Option<PathBuf>,
     pub cache_ttl_seconds: u64,
+    pub record_history: bool,
+    pub report_store_dir: Option<PathBuf>,
     pub cancel_flag: Option<Arc<AtomicBool>>,
 }
 
@@ -90,6 +92,8 @@ impl Default for ScanOptions {
             incremental_cache: false,
             cache_dir: None,
             cache_ttl_seconds: DEFAULT_CACHE_TTL_SECONDS,
+            record_history: true,
+            report_store_dir: None,
             cancel_flag: None,
         }
     }
@@ -577,18 +581,16 @@ where
     };
 
     // Run general recommendations
-    let recommendation_bundle = generate_recommendation_bundle(&report);
+    let recommendation_bundle = generate_recommendation_bundle_with_context(
+        &report,
+        &AnalyzerContext {
+            report_store_dir: options.report_store_dir.clone(),
+        },
+    );
     report.recommendations = recommendation_bundle.recommendations;
     report.policy_decisions = recommendation_bundle.policy_decisions;
     report.rule_traces = recommendation_bundle.rule_traces;
     report.scan_metrics.contradiction_count = recommendation_bundle.contradiction_count;
-
-    // Run specific analyzers
-    let analyzer_results = analyzers::run_analyzers(&report);
-    for result in analyzer_results {
-        report.recommendations.extend(result.recommendations);
-        report.rule_traces.extend(result.traces);
-    }
 
     report.scan_metrics.permission_denied_warnings = report
         .warnings
@@ -623,8 +625,8 @@ where
 
     persist_cached_report(options, &roots, &mut report);
 
-    if !options.dry_run {
-        if let Err(err) = append_scan_to_history(&report) {
+    if options.record_history {
+        if let Err(err) = append_scan_to_history(&report, options.report_store_dir.as_deref()) {
             append_warning_once(
                 &mut report.warnings,
                 format!("Failed to append scan to history: {}", err),
@@ -635,8 +637,8 @@ where
     Ok(report)
 }
 
-fn append_scan_to_history(report: &Report) -> Result<()> {
-    let mut history = history::load_history()?;
+fn append_scan_to_history(report: &Report, report_store_dir: Option<&Path>) -> Result<()> {
+    let mut history = history::load_history(report_store_dir)?;
 
     let snapshot = crate::model::ScanSnapshot {
         scan_id: report.scan_id.clone(),
@@ -662,7 +664,7 @@ fn append_scan_to_history(report: &Report) -> Result<()> {
     };
 
     history.snapshots.push(snapshot);
-    history::save_history(&history)?;
+    history::save_history(&history, report_store_dir)?;
     Ok(())
 }
 
@@ -702,10 +704,12 @@ pub fn compare_backends(options: &ScanOptions) -> Result<BackendParity> {
     let mut native = options.clone();
     native.backend = ScanBackendKind::Native;
     native.emit_progress_events = false;
+    native.record_history = false;
 
     let mut pdu = options.clone();
     pdu.backend = ScanBackendKind::PduLibrary;
     pdu.emit_progress_events = false;
+    pdu.record_history = false;
 
     let native_report = run_scan(&native)?;
     let pdu_report = run_scan(&pdu)?;
@@ -1518,6 +1522,7 @@ mod tests {
     fn validates_min_ratio_bounds() {
         let options = ScanOptions {
             min_ratio: Some(1.2),
+            record_history: false,
             ..ScanOptions::default()
         };
         assert!(validate_scan_options(&options).is_err());
@@ -1528,6 +1533,7 @@ mod tests {
         let options = ScanOptions {
             incremental_cache: true,
             cache_ttl_seconds: 0,
+            record_history: false,
             ..ScanOptions::default()
         };
         assert!(validate_scan_options(&options).is_err());
@@ -1545,6 +1551,7 @@ mod tests {
             incremental_cache: true,
             cache_dir: Some(cache_dir.path().to_path_buf()),
             cache_ttl_seconds: 900,
+            record_history: false,
             ..ScanOptions::default()
         };
 
@@ -1577,6 +1584,7 @@ mod tests {
             incremental_cache: true,
             cache_dir: Some(cache_dir.path().to_path_buf()),
             cache_ttl_seconds: 900,
+            record_history: false,
             ..ScanOptions::default()
         };
 

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod service;
 
 pub use service::{
-    cancel_scan, doctor, export_diagnostics_bundle, generate_recommendations_from_report,
-    get_scan_session, load_report, plan_scenarios_from_report, poll_scan_events, start_scan,
-    CancelScanResponse, ScanRequest, ScanSessionSnapshot, ScanSessionStatus,
+    cancel_scan, compare_reports, doctor, export_diagnostics_bundle, export_markdown_summary,
+    export_report_diff, generate_recommendations_from_report, get_report, get_scan_session,
+    import_report, list_reports, load_report, plan_scenarios_from_report, poll_scan_events,
+    start_scan, CancelScanResponse, ScanRequest, ScanSessionSnapshot, ScanSessionStatus,
 };

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -12,8 +12,11 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use storage_strategist_core::{
     build_diagnostics_bundle, build_scenario_plan, collect_doctor_info,
-    generate_recommendation_bundle, run_scan_with_callback, write_diagnostics_bundle,
-    DiagnosticsBundle, DoctorInfo, RecommendationBundle, Report, ScanBackendKind, ScanOptions,
+    compare_reports as compare_saved_reports, generate_recommendation_bundle,
+    get_report as load_saved_report, import_report as import_saved_report,
+    list_reports as list_saved_reports, render_markdown_summary, run_scan_with_callback,
+    store_report, write_diagnostics_bundle, DiagnosticsBundle, DoctorInfo, RecommendationBundle,
+    Report, ReportDiff, ReportImportResult, ReportSummary, ScanBackendKind, ScanOptions,
     ScanProgressEvent, ScenarioPlan,
 };
 use uuid::Uuid;
@@ -50,6 +53,10 @@ pub struct ScanRequest {
     pub cache_dir: Option<PathBuf>,
     #[serde(default = "default_cache_ttl_seconds")]
     pub cache_ttl_seconds: u64,
+    #[serde(default = "default_record_history")]
+    pub record_history: bool,
+    #[serde(default)]
+    pub report_store_dir: Option<PathBuf>,
 }
 
 fn default_dedupe_min_size() -> u64 {
@@ -66,6 +73,10 @@ fn default_incremental_cache() -> bool {
 
 fn default_cache_ttl_seconds() -> u64 {
     900
+}
+
+fn default_record_history() -> bool {
+    true
 }
 
 impl Default for ScanRequest {
@@ -86,6 +97,8 @@ impl Default for ScanRequest {
             incremental_cache: default_incremental_cache(),
             cache_dir: None,
             cache_ttl_seconds: default_cache_ttl_seconds(),
+            record_history: default_record_history(),
+            report_store_dir: None,
         }
     }
 }
@@ -151,6 +164,8 @@ pub fn start_scan(request: ScanRequest) -> Result<String> {
 
     let thread_scan_id = scan_id.clone();
     thread::spawn(move || {
+        let output_path = request.output.clone();
+        let report_store_dir = request.report_store_dir.clone();
         let options = ScanOptions {
             paths: request.paths,
             max_depth: request.max_depth,
@@ -167,6 +182,8 @@ pub fn start_scan(request: ScanRequest) -> Result<String> {
             incremental_cache: request.incremental_cache,
             cache_dir: request.cache_dir,
             cache_ttl_seconds: request.cache_ttl_seconds,
+            record_history: request.record_history,
+            report_store_dir: report_store_dir.clone(),
             cancel_flag: Some(Arc::clone(&cancel_flag)),
             ..ScanOptions::default()
         };
@@ -181,7 +198,7 @@ pub fn start_scan(request: ScanRequest) -> Result<String> {
 
         match run_result {
             Ok(report) => {
-                if let Some(path) = &request.output {
+                if let Some(path) = &output_path {
                     let write_result = serde_json::to_string_pretty(&report)
                         .context("failed to serialize report payload")
                         .and_then(|payload| {
@@ -201,9 +218,30 @@ pub fn start_scan(request: ScanRequest) -> Result<String> {
                     }
                 }
 
+                let store_result = store_report(
+                    &report,
+                    report_store_dir.as_deref(),
+                    output_path.as_deref(),
+                    false,
+                );
+                let stored_summary = match store_result {
+                    Ok(summary) => summary,
+                    Err(err) => {
+                        if let Ok(mut sessions) = lock_sessions() {
+                            if let Some(session) = sessions.get_mut(&thread_scan_id) {
+                                session.status = ScanSessionStatus::Failed;
+                                session.error = Some(err.to_string());
+                            }
+                        }
+                        return;
+                    }
+                };
+
                 if let Ok(mut sessions) = lock_sessions() {
                     if let Some(session) = sessions.get_mut(&thread_scan_id) {
                         session.report = Some(report);
+                        session.report_path =
+                            Some(PathBuf::from(&stored_summary.stored_report_path));
                         session.status = if cancel_flag.load(Ordering::Relaxed) {
                             ScanSessionStatus::Cancelled
                         } else {
@@ -267,6 +305,29 @@ pub fn load_report(path: impl AsRef<Path>) -> Result<Report> {
     Ok(report)
 }
 
+pub fn list_reports(report_store_dir: Option<&Path>) -> Result<Vec<ReportSummary>> {
+    list_saved_reports(report_store_dir)
+}
+
+pub fn get_report(scan_id: &str, report_store_dir: Option<&Path>) -> Result<Report> {
+    load_saved_report(scan_id, report_store_dir)
+}
+
+pub fn import_report(
+    path: impl AsRef<Path>,
+    report_store_dir: Option<&Path>,
+) -> Result<ReportImportResult> {
+    import_saved_report(path, report_store_dir)
+}
+
+pub fn compare_reports(
+    left_scan_id: &str,
+    right_scan_id: &str,
+    report_store_dir: Option<&Path>,
+) -> Result<ReportDiff> {
+    compare_saved_reports(left_scan_id, right_scan_id, report_store_dir)
+}
+
 pub fn generate_recommendations_from_report(report: &Report) -> RecommendationBundle {
     generate_recommendation_bundle(report)
 }
@@ -283,6 +344,29 @@ pub fn export_diagnostics_bundle(
     let bundle = build_diagnostics_bundle(report, source_report_path.as_deref());
     write_diagnostics_bundle(&bundle, output)?;
     Ok(bundle)
+}
+
+pub fn export_markdown_summary(report: &Report, output: impl AsRef<Path>) -> Result<()> {
+    let markdown = render_markdown_summary(report, &report.recommendations);
+    fs::write(output.as_ref(), markdown).with_context(|| {
+        format!(
+            "failed to write markdown summary to {}",
+            output.as_ref().display()
+        )
+    })?;
+    Ok(())
+}
+
+pub fn export_report_diff(diff: &ReportDiff, output: impl AsRef<Path>) -> Result<()> {
+    let payload =
+        serde_json::to_string_pretty(diff).context("failed to serialize report diff payload")?;
+    fs::write(output.as_ref(), payload).with_context(|| {
+        format!(
+            "failed to write report diff to {}",
+            output.as_ref().display()
+        )
+    })?;
+    Ok(())
 }
 
 pub fn doctor() -> DoctorInfo {
@@ -325,6 +409,7 @@ mod tests {
             paths: vec![std::env::current_dir().expect("cwd")],
             max_depth: Some(1),
             emit_progress_events: true,
+            record_history: false,
             ..ScanRequest::default()
         };
         let scan_id = start_scan(request).expect("scan succeeds");


### PR DESCRIPTION
## Linked issue

Linked issue: #7

## Summary

Build the analyst foundations slice of the roadmap by introducing a persistent local report store, saved-report import/show/diff flows, and desktop reopen/compare workflows. This also routes analyzer recommendations through the shared policy pipeline and adds structured evidence plus next-step guidance to recommendations.

## Affected scope

- [x] core
- [x] cli
- [x] desktop
- [ ] compliance
- [ ] infra
- [x] docs
- [x] shared

## Validation

- [x] fmt
- [x] clippy
- [x] test
- [x] compliance checks
- [x] desktop smoke
- [x] Other validation is described below
- [ ] Not run (reason described below)

Validation notes:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `python scripts/check_compliance.py`
- `npm run build` in `apps/desktop`
- `npm run test:e2e` in `apps/desktop`
- `cargo check` in `apps/desktop/src-tauri`

## Visible UI changes

- [ ] No visible UI changes
- [x] Screenshot(s) or preview link added below

UI evidence:
- Desktop workbench now includes a saved-report library on the home screen, reopen/import actions, a compare screen, recommendation evidence panels, and new export actions. Local UI behavior was validated through the desktop smoke flow and production build for this branch.

## Compliance impact

- [x] No compliance/provenance changes
- [ ] Compliance or provenance updates are included
- [ ] `provenance/imported_code.json` updated where applicable
- [ ] `THIRD_PARTY_NOTICES.md` updated where applicable

Compliance notes:
- No imported-code or provenance surface changed in this PR.

## Docs impact

- [ ] No docs changes required
- [x] Docs updated in this PR
- [ ] Docs follow-up issue linked below

Docs notes:
- Updated the root README and desktop README for saved-report workflows and desktop library/compare behavior.

## Rollback notes

- [x] Not risky / not production impacting
- [ ] Rollback plan included below

Rollback plan:
- Revert the squash commit for this PR to remove the report-store, saved-report, and desktop workbench changes as one unit.

## Trivial docs-only exception

- [ ] This PR changes only `docs/**`, `*.md`, or `*.txt`
- [ ] This PR does not touch workflows, configs, schemas, scripts, or code
