### PR TITLE
fix(shared): harden saved report reopen boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,6 +1169,7 @@ dependencies = [
  "serde",
  "serde_json",
  "storage-strategist-core",
+ "tempfile",
  "uuid",
 ]
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,7 +8,6 @@ import {
   exportDiagnosticsBundle,
   exportMarkdownSummary,
   exportReportDiff,
-  generateRecommendations,
   getReport,
   getScanSession,
   importReport,
@@ -129,6 +128,7 @@ function App() {
   const [session, setSession] = useState<ScanSessionSnapshot | null>(null);
   const [events, setEvents] = useState<ScanProgressEvent[]>([]);
   const [report, setReport] = useState<Report | null>(null);
+  const [activeReportPath, setActiveReportPath] = useState<string | null>(null);
   const [reportLibrary, setReportLibrary] = useState<ReportSummary[]>([]);
   const [reportDiff, setReportDiff] = useState<ReportDiff | null>(null);
   const [leftCompareId, setLeftCompareId] = useState<string>("");
@@ -192,16 +192,17 @@ function App() {
         }
 
         if (snapshot.status === "completed") {
-          const loaded =
+          const storedReportPath =
             snapshot.report_path !== undefined && snapshot.report_path !== null
-              ? await loadReport(snapshot.report_path)
-              : await getReport(scanId);
+              ? snapshot.report_path
+              : null;
+          const loaded = storedReportPath ? await loadReport(storedReportPath) : await getReport(scanId);
 
           if (!isActive) {
             return;
           }
 
-          await loadWorkbenchReport(loaded);
+          await loadWorkbenchReport(loaded, storedReportPath);
           await refreshReportLibrary();
           setNotice(null);
         }
@@ -366,21 +367,18 @@ function App() {
     });
   }, [report, recommendationEvidenceFilter, recommendationFilter, recommendationPolicyFilter]);
 
-  const loadWorkbenchReport = async (loaded: Report) => {
-    const bundle = await generateRecommendations(loaded);
-    const nextReport = {
-      ...loaded,
-      recommendations: bundle.recommendations,
-      policy_decisions: bundle.policy_decisions,
-      rule_traces: bundle.rule_traces,
-    };
-    const nextScenarioPlan = await planScenarios(nextReport);
+  const loadWorkbenchReport = async (
+    loaded: Report,
+    reportPath?: string | null
+  ) => {
+    const nextScenarioPlan = await planScenarios(loaded);
 
-    setReport(nextReport);
-    setScanId(nextReport.scan_id);
+    setReport(loaded);
+    setActiveReportPath(reportPath?.trim() || null);
+    setScanId(loaded.scan_id);
     setSession(null);
     setScenarioPlan(nextScenarioPlan);
-    setSelectedRecommendationId(nextReport.recommendations[0]?.id ?? null);
+    setSelectedRecommendationId(loaded.recommendations[0]?.id ?? null);
     setTraceStatusFilter("all");
     setTraceRecommendationFilter("all");
     setRecommendationFilter("");
@@ -393,13 +391,13 @@ function App() {
     setScreen("results");
   };
 
-  const openStoredReport = async (storedScanId: string) => {
+  const openStoredReport = async (summary: ReportSummary) => {
     setError(null);
     setNotice(null);
     try {
-      const storedReport = await getReport(storedScanId);
-      await loadWorkbenchReport(storedReport);
-      setNotice(`Opened saved report ${storedScanId}.`);
+      const storedReport = await loadReport(summary.stored_report_path);
+      await loadWorkbenchReport(storedReport, summary.stored_report_path);
+      setNotice(`Opened saved report ${summary.scan_id}.`);
     } catch (storedReportError) {
       setError(String(storedReportError));
     }
@@ -419,7 +417,7 @@ function App() {
       }
       const result = await importReport(selection);
       await refreshReportLibrary();
-      await openStoredReport(result.summary.scan_id);
+      await openStoredReport(result.summary);
       setNotice(`Imported ${result.summary.scan_id} into the local report library.`);
     } catch (importError) {
       setError(String(importError));
@@ -472,6 +470,7 @@ function App() {
       setEvents([]);
       setSession(null);
       setReport(null);
+      setActiveReportPath(null);
       setScenarioPlan(null);
       const id = await startScan(request);
       setScanId(id);
@@ -507,7 +506,7 @@ function App() {
     setError(null);
     setNotice(null);
     try {
-      const sourcePath = session?.report_path ?? output;
+      const sourcePath = activeReportPath ?? session?.report_path ?? output;
       const outputPath = deriveDiagnosticsOutputPath(sourcePath);
       const bundle = await exportDiagnosticsBundle(report, outputPath, sourcePath);
       setNotice(
@@ -525,7 +524,7 @@ function App() {
     setError(null);
     setNotice(null);
     try {
-      const sourcePath = session?.report_path ?? output;
+      const sourcePath = activeReportPath ?? session?.report_path ?? output;
       const outputPath = deriveMarkdownOutputPath(sourcePath);
       await exportMarkdownSummary(report, outputPath);
       setNotice(`Markdown review summary written to ${outputPath}.`);
@@ -667,7 +666,7 @@ function App() {
                       <p>stored at {item.stored_report_path}</p>
                       <p>source path {item.source_path ?? "library-generated"}</p>
                       <div className="row end">
-                        <button onClick={() => openStoredReport(item.scan_id)}>Open Report</button>
+                        <button onClick={() => openStoredReport(item)}>Open Report</button>
                       </div>
                     </article>
                   ))}

--- a/apps/desktop/tests/smoke.spec.ts
+++ b/apps/desktop/tests/smoke.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-const mockReport = {
+const storedReport = {
   scan_id: "scan-e2e-1",
   report_version: "1.3.0",
   generated_at: "2026-02-12T00:00:00Z",
@@ -78,37 +78,68 @@ const mockReport = {
   warnings: [],
 };
 
+const importedReport = {
+  ...storedReport,
+  scan_id: "../legacy-import",
+  generated_at: "2026-02-13T00:00:00Z",
+  recommendations: [
+    {
+      id: "stored-imported-recommendation",
+      title: "Stored imported recommendation",
+      rationale: "Imported reports should reopen exactly as stored.",
+      confidence: 0.33,
+      target_mount: "D:\\",
+      policy_safe: false,
+      policy_rules_applied: ["imported_policy"],
+      policy_rules_blocked: ["blocked_for_review"],
+      estimated_impact: {
+        space_saving_bytes: 1024,
+        performance: "Stored planner note",
+        risk_notes: "Stored imported risk note.",
+      },
+      risk_level: "high",
+      evidence: [
+        {
+          kind: "warning",
+          label: "Stored imported evidence",
+          detail: "This value should survive reopen without recomputation.",
+          mount_point: "D:\\",
+        },
+      ],
+      next_steps: ["Review the stored imported evidence."],
+    },
+  ],
+  policy_decisions: [
+    {
+      policy_id: "imported_policy",
+      recommendation_id: "stored-imported-recommendation",
+      action: "blocked",
+      rationale: "Imported policy decisions must stay intact.",
+    },
+  ],
+  rule_traces: [
+    {
+      rule_id: "imported_rule_trace",
+      status: "rejected",
+      detail: "Stored imported trace detail.",
+      recommendation_id: "stored-imported-recommendation",
+      confidence: 0.21,
+    },
+  ],
+};
+
 const mockDoctor = {
   os: "windows",
   arch: "x86_64",
   read_only_mode: true,
-  disks: mockReport.disks,
+  disks: storedReport.disks,
   notes: [],
-};
-
-const mockScenarioPlan = {
-  generated_at: "2026-02-12T00:00:03Z",
-  scan_id: "scan-e2e-1",
-  assumptions: ["Read-only simulation"],
-  scenarios: [
-    {
-      scenario_id: "conservative",
-      title: "Conservative",
-      strategy: "conservative",
-      recommendation_ids: ["cloud-backed-target-exclusion"],
-      recommendation_count: 1,
-      projected_space_saving_bytes: 0,
-      risk_mix: { low: 1, medium: 0, high: 0 },
-      blocked_recommendation_count: 0,
-      notes: [],
-    },
-  ],
 };
 
 const mockEvents = [
   {
     seq: 1,
-    scan_id: "scan-e2e-1",
+    scan_id: storedReport.scan_id,
     phase: "walking_files",
     current_path: "D:\\Demo",
     scanned_files: 10,
@@ -118,7 +149,7 @@ const mockEvents = [
   },
   {
     seq: 2,
-    scan_id: "scan-e2e-1",
+    scan_id: storedReport.scan_id,
     phase: "done",
     current_path: null,
     scanned_files: 12,
@@ -128,17 +159,30 @@ const mockEvents = [
   },
 ];
 
-const mockReportSummary = {
-  scan_id: mockReport.scan_id,
-  generated_at: mockReport.generated_at,
-  report_version: mockReport.report_version,
+const storedSummary = {
+  scan_id: storedReport.scan_id,
+  generated_at: storedReport.generated_at,
+  report_version: storedReport.report_version,
   roots: ["D:\\Demo"],
   backend: "native",
   warnings_count: 0,
-  recommendation_count: mockReport.recommendations.length,
-  stored_report_path: "mock-report.json",
-  source_path: "mock-report.json",
+  recommendation_count: storedReport.recommendations.length,
+  stored_report_path: "D:\\Library\\stored-report.json",
+  source_path: "D:\\Library\\stored-report.json",
   imported: false,
+};
+
+const importedSummary = {
+  scan_id: importedReport.scan_id,
+  generated_at: importedReport.generated_at,
+  report_version: importedReport.report_version,
+  roots: ["D:\\Demo"],
+  backend: "native",
+  warnings_count: 0,
+  recommendation_count: importedReport.recommendations.length,
+  stored_report_path: "D:\\Library\\imported-legacy-report.json",
+  source_path: "D:\\Imports\\legacy-report.json",
+  imported: true,
 };
 
 const mockReportDiff = {
@@ -152,66 +196,108 @@ const mockReportDiff = {
   recommendation_changes: [],
 };
 
+async function getTauriCalls(page: Page) {
+  return page.evaluate(() => {
+    return (
+      window as unknown as {
+        __mockTauriState__: { calls: Array<{ command: string; payload?: Record<string, unknown> }> };
+      }
+    ).__mockTauriState__.calls;
+  });
+}
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(
-    ({ report, doctor, events, scenarioPlan, reportSummary, reportDiff }) => {
-      let sessionCalls = 0;
-      let eventCalls = 0;
-      const scanId = report.scan_id;
+    ({ report, imported, doctor, events, reportSummary, importedReportSummary, reportDiff }) => {
+      const state = {
+        calls: [] as Array<{ command: string; payload?: Record<string, unknown> }>,
+        sessionCalls: 0,
+        eventCalls: 0,
+      };
+
+      const buildScenarioPlan = (activeReport: typeof report) => ({
+        generated_at: "2026-02-12T00:00:03Z",
+        scan_id: activeReport.scan_id,
+        assumptions: ["Read-only simulation"],
+        scenarios: [
+          {
+            scenario_id: "conservative",
+            title: "Conservative",
+            strategy: "conservative",
+            recommendation_ids: activeReport.recommendations.map((entry) => entry.id),
+            recommendation_count: activeReport.recommendations.length,
+            projected_space_saving_bytes:
+              activeReport.recommendations[0]?.estimated_impact?.space_saving_bytes ?? 0,
+            risk_mix: { low: 1, medium: 0, high: 0 },
+            blocked_recommendation_count: activeReport.recommendations.filter(
+              (entry) => !entry.policy_safe
+            ).length,
+            notes: [],
+          },
+        ],
+      });
 
       (
         window as unknown as {
-          __TAURI_INTERNALS__: { invoke: (...args: unknown[]) => Promise<unknown> };
+          __TAURI_INTERNALS__: {
+            invoke: (command: string, payload?: Record<string, unknown>) => Promise<unknown>;
+          };
+          __mockTauriState__: typeof state;
+        }
+      ).__mockTauriState__ = state;
+
+      (
+        window as unknown as {
+          __TAURI_INTERNALS__: {
+            invoke: (command: string, payload?: Record<string, unknown>) => Promise<unknown>;
+          };
         }
       ).__TAURI_INTERNALS__ = {
-        invoke: async (command: string) => {
+        invoke: async (command: string, payload?: Record<string, unknown>) => {
+          state.calls.push({ command, payload });
+
           switch (command) {
             case "start_scan":
-              return scanId;
+              return report.scan_id;
             case "poll_scan_events":
-              eventCalls += 1;
-              return eventCalls === 1 ? events : [];
+              state.eventCalls += 1;
+              return state.eventCalls === 1 ? events : [];
             case "get_scan_session":
-              sessionCalls += 1;
-              if (sessionCalls < 2) {
+              state.sessionCalls += 1;
+              if (state.sessionCalls < 2) {
                 return {
-                  scan_id: scanId,
+                  scan_id: report.scan_id,
                   status: "running",
                   total_events: 0,
                 };
               }
               return {
-                scan_id: scanId,
+                scan_id: report.scan_id,
                 status: "completed",
-                report_path: "mock-report.json",
+                report_path: reportSummary.stored_report_path,
                 total_events: events.length,
               };
             case "load_report":
-              return report;
+              return payload?.path === importedReportSummary.stored_report_path ? imported : report;
             case "list_reports":
-              return [reportSummary];
+              return [reportSummary, importedReportSummary];
             case "get_report":
               return report;
             case "import_report":
-              return { summary: reportSummary };
+              return { summary: importedReportSummary };
             case "compare_reports":
               return reportDiff;
             case "generate_recommendations":
-              return {
-                recommendations: report.recommendations,
-                policy_decisions: report.policy_decisions,
-                rule_traces: report.rule_traces,
-                contradiction_count: 0,
-              };
+              throw new Error("generate_recommendations should not run during reopen/import flows");
             case "plan_scenarios":
-              return scenarioPlan;
+              return buildScenarioPlan((payload?.report as typeof report) ?? report);
             case "doctor":
               return doctor;
             case "export_diagnostics_bundle":
               return {
                 generated_at: "2026-02-12T00:00:04Z",
-                source_report_path: "mock-report.json",
-                report,
+                source_report_path: payload?.sourceReportPath,
+                report: payload?.report,
                 doctor,
                 environment: {
                   os: "windows",
@@ -220,8 +306,12 @@ test.beforeEach(async ({ page }) => {
                   app_version: "0.1.0",
                 },
               };
+            case "export_markdown_summary":
+            case "export_report_diff":
             case "cancel_scan":
               return null;
+            case "plugin:dialog|open":
+              return "D:\\Imports\\legacy-report.json";
             default:
               throw new Error(`Unexpected Tauri command in smoke test: ${command}`);
           }
@@ -229,11 +319,12 @@ test.beforeEach(async ({ page }) => {
       };
     },
     {
-      report: mockReport,
+      report: storedReport,
+      imported: importedReport,
       doctor: mockDoctor,
       events: mockEvents,
-      scenarioPlan: mockScenarioPlan,
-      reportSummary: mockReportSummary,
+      reportSummary: storedSummary,
+      importedReportSummary: importedSummary,
       reportDiff: mockReportDiff,
     }
   );
@@ -265,7 +356,85 @@ test("setup to results to doctor smoke flow", async ({ page }) => {
     })
   ).toBeVisible();
 
+  const commands = (await getTauriCalls(page)).map((entry) => entry.command);
+  expect(commands).not.toContain("generate_recommendations");
+
   await page.getByRole("button", { name: "Doctor" }).click();
   await expect(page.getByRole("heading", { name: "Doctor" })).toBeVisible();
   await expect(page.getByText("Detected disks: 1")).toBeVisible();
+});
+
+test("reopening a saved report keeps the stored recommendations and traces", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Open Report" }).first().click();
+
+  await expect(page.getByRole("heading", { name: "Results Workbench" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      name: "Cloud-backed drives excluded from local placement targets",
+    })
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Open in Rule Trace" }).click();
+  await expect(page.getByText("cloud_exclusion_notice")).toBeVisible();
+
+  const calls = await getTauriCalls(page);
+  expect(calls.filter((entry) => entry.command === "generate_recommendations")).toHaveLength(0);
+  expect(calls.filter((entry) => entry.command === "load_report")).toContainEqual({
+    command: "load_report",
+    payload: { path: storedSummary.stored_report_path },
+  });
+});
+
+test("imported reports reopen from the stored path and exports use stored provenance", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Import Report..." }).click();
+
+  await expect(page.getByRole("heading", { name: "Results Workbench" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      name: "Stored imported recommendation",
+    })
+  ).toBeVisible();
+  await expect(page.getByText("Imported ../legacy-import into the local report library.")).toBeVisible();
+
+  let calls = await getTauriCalls(page);
+  expect(calls.filter((entry) => entry.command === "generate_recommendations")).toHaveLength(0);
+  expect(calls.filter((entry) => entry.command === "load_report")).toContainEqual({
+    command: "load_report",
+    payload: { path: importedSummary.stored_report_path },
+  });
+
+  await page.getByRole("button", { name: "Export Markdown Summary" }).click();
+  await expect(
+    page.getByText("Markdown review summary written to D:\\Library\\imported-legacy-report.md.")
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Export Diagnostics Bundle" }).click();
+  await expect(
+    page.getByText(
+      "Diagnostics bundle written to D:\\Library\\imported-legacy-report.diagnostics.json"
+    )
+  ).toBeVisible();
+
+  calls = await getTauriCalls(page);
+
+  expect(calls).toContainEqual({
+    command: "export_markdown_summary",
+    payload: {
+      report: importedReport,
+      outputPath: "D:\\Library\\imported-legacy-report.md",
+    },
+  });
+  expect(calls).toContainEqual({
+    command: "export_diagnostics_bundle",
+    payload: {
+      report: importedReport,
+      outputPath: "D:\\Library\\imported-legacy-report.diagnostics.json",
+      sourceReportPath: importedSummary.stored_report_path,
+    },
+  });
 });

--- a/crates/core/src/reports.rs
+++ b/crates/core/src/reports.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::model::{
@@ -16,6 +16,7 @@ const STORE_DIR_NAME: &str = "report-store";
 const REPORTS_DIR_NAME: &str = "reports";
 const INDEX_FILE_NAME: &str = "index.json";
 const HISTORY_FILE_NAME: &str = "history.json";
+const HASHED_SCAN_ID_PREFIX: &str = "__scan_id_blake3__";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct ReportIndex {
@@ -56,12 +57,12 @@ pub fn history_file_path(custom_dir: Option<&Path>) -> PathBuf {
 }
 
 pub fn report_path_for_scan(scan_id: &str, custom_dir: Option<&Path>) -> PathBuf {
-    reports_dir(custom_dir).join(format!("{scan_id}.json"))
+    reports_dir(custom_dir).join(format!("{}.json", report_file_stem_for_scan(scan_id)))
 }
 
 pub fn list_reports(custom_dir: Option<&Path>) -> Result<Vec<ReportSummary>> {
     let mut index = load_index(custom_dir)?;
-    let changed = cleanup_orphaned_entries(&mut index);
+    let changed = cleanup_orphaned_entries(&mut index, custom_dir)?;
     sort_reports(&mut index.reports);
     if changed {
         save_index(custom_dir, &index)?;
@@ -85,9 +86,15 @@ pub fn store_report(
             stored_report_path.display()
         )
     })?;
+    let stored_report_path = fs::canonicalize(&stored_report_path).with_context(|| {
+        format!(
+            "failed to canonicalize stored report {}",
+            stored_report_path.display()
+        )
+    })?;
 
     let mut index = load_index(custom_dir)?;
-    cleanup_orphaned_entries(&mut index);
+    cleanup_orphaned_entries(&mut index, custom_dir)?;
 
     let summary = build_summary(report, &stored_report_path, source_path, imported);
     index
@@ -114,7 +121,7 @@ pub fn import_report(
 }
 
 pub fn get_report(scan_id: &str, custom_dir: Option<&Path>) -> Result<Report> {
-    let path = report_path_for_scan(scan_id, custom_dir);
+    let path = resolve_existing_report_path(scan_id, custom_dir)?;
     let payload = fs::read_to_string(&path)
         .with_context(|| format!("failed to read stored report {}", path.display()))?;
     let report: Report = serde_json::from_str(&payload)
@@ -373,6 +380,79 @@ fn reports_dir(custom_dir: Option<&Path>) -> PathBuf {
     resolve_report_store_dir(custom_dir).join(REPORTS_DIR_NAME)
 }
 
+fn report_file_stem_for_scan(scan_id: &str) -> String {
+    if can_use_raw_scan_id_stem(scan_id) {
+        scan_id.to_string()
+    } else {
+        format!(
+            "{HASHED_SCAN_ID_PREFIX}{}",
+            blake3::hash(scan_id.as_bytes()).to_hex()
+        )
+    }
+}
+
+fn can_use_raw_scan_id_stem(scan_id: &str) -> bool {
+    !scan_id.is_empty()
+        && scan_id != "."
+        && scan_id != ".."
+        && !scan_id.starts_with(HASHED_SCAN_ID_PREFIX)
+        && scan_id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn legacy_report_path_for_scan(scan_id: &str, custom_dir: Option<&Path>) -> PathBuf {
+    reports_dir(custom_dir).join(format!("{scan_id}.json"))
+}
+
+fn resolve_existing_report_path(scan_id: &str, custom_dir: Option<&Path>) -> Result<PathBuf> {
+    let canonical = report_path_for_scan(scan_id, custom_dir);
+    if let Some(path) = validated_existing_report_path(&canonical, custom_dir)? {
+        return Ok(path);
+    }
+
+    let legacy = legacy_report_path_for_scan(scan_id, custom_dir);
+    if legacy != canonical {
+        if let Some(path) = validated_existing_report_path(&legacy, custom_dir)? {
+            return Ok(path);
+        }
+    }
+
+    Err(anyhow!(
+        "stored report not found for scan_id {}",
+        escape_scan_id_for_error(scan_id)
+    ))
+}
+
+fn validated_existing_report_path(
+    candidate: &Path,
+    custom_dir: Option<&Path>,
+) -> Result<Option<PathBuf>> {
+    if !candidate.exists() {
+        return Ok(None);
+    }
+
+    let reports_root = reports_dir(custom_dir);
+    if !reports_root.exists() {
+        return Ok(None);
+    }
+
+    let canonical_reports_root = fs::canonicalize(&reports_root).with_context(|| {
+        format!(
+            "failed to canonicalize reports directory {}",
+            reports_root.display()
+        )
+    })?;
+    let canonical_candidate = fs::canonicalize(candidate)
+        .with_context(|| format!("failed to canonicalize {}", candidate.display()))?;
+
+    if canonical_candidate.starts_with(&canonical_reports_root) {
+        Ok(Some(canonical_candidate))
+    } else {
+        Ok(None)
+    }
+}
+
 fn index_file_path(custom_dir: Option<&Path>) -> PathBuf {
     resolve_report_store_dir(custom_dir).join(INDEX_FILE_NAME)
 }
@@ -400,12 +480,26 @@ fn save_index(custom_dir: Option<&Path>, index: &ReportIndex) -> Result<()> {
     Ok(())
 }
 
-fn cleanup_orphaned_entries(index: &mut ReportIndex) -> bool {
-    let before = index.reports.len();
-    index
-        .reports
-        .retain(|entry| Path::new(&entry.stored_report_path).exists());
-    before != index.reports.len()
+fn cleanup_orphaned_entries(index: &mut ReportIndex, custom_dir: Option<&Path>) -> Result<bool> {
+    let mut changed = false;
+    let mut retained = Vec::with_capacity(index.reports.len());
+
+    for mut entry in index.reports.drain(..) {
+        match validated_existing_report_path(Path::new(&entry.stored_report_path), custom_dir)? {
+            Some(path) => {
+                let canonical = path.to_string_lossy().to_string();
+                if entry.stored_report_path != canonical {
+                    entry.stored_report_path = canonical;
+                    changed = true;
+                }
+                retained.push(entry);
+            }
+            None => changed = true,
+        }
+    }
+
+    index.reports = retained;
+    Ok(changed)
 }
 
 fn sort_reports(reports: &mut [ReportSummary]) {
@@ -431,9 +525,24 @@ fn signed_delta(left: Option<u64>, right: Option<u64>) -> i64 {
     })
 }
 
+fn escape_scan_id_for_error(scan_id: &str) -> String {
+    let mut escaped = String::new();
+    for ch in scan_id.chars() {
+        match ch {
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{build_report_diff, store_report};
+    use std::fs;
+
+    use super::{build_report_diff, get_report, import_report, list_reports, store_report};
     use crate::model::{
         EstimatedImpact, Recommendation, RecommendationEvidence, RecommendationEvidenceKind,
         Report, RiskLevel, ScanBackendKind, ScanMetadata, ScanMetrics,
@@ -462,6 +571,77 @@ mod tests {
         assert_eq!(diff.path_diffs.len(), 1);
         assert_eq!(diff.recommendation_changes.len(), 1);
         assert!(diff.duplicate_wasted_bytes_delta > 0);
+    }
+
+    #[test]
+    fn stores_traversal_like_scan_ids_inside_report_store() {
+        let dir = tempdir().expect("temp dir");
+        let report = sample_report("..\\..\\outside", 100, 1);
+
+        let summary = store_report(&report, Some(dir.path()), None, false).expect("stored report");
+        let stored_path =
+            fs::canonicalize(&summary.stored_report_path).expect("stored report canonicalized");
+        let reports_dir = fs::canonicalize(dir.path().join("reports")).expect("reports dir");
+
+        assert!(stored_path.starts_with(&reports_dir));
+    }
+
+    #[test]
+    fn imported_report_with_traversal_like_scan_id_round_trips_safely() {
+        let dir = tempdir().expect("temp dir");
+        let source = dir.path().join("legacy-report.json");
+        let report = sample_report("../legacy-report", 100, 1);
+        let payload = serde_json::to_string_pretty(&report).expect("serialize report");
+        fs::write(&source, payload).expect("write source report");
+
+        let result = import_report(&source, Some(dir.path())).expect("import report");
+        let loaded = get_report(&report.scan_id, Some(dir.path())).expect("load imported report");
+        let stored_path =
+            fs::canonicalize(&result.summary.stored_report_path).expect("stored report path");
+        let reports_dir = fs::canonicalize(dir.path().join("reports")).expect("reports dir");
+        let expected_source = source.to_string_lossy().to_string();
+
+        assert_eq!(loaded.scan_id, report.scan_id);
+        assert_eq!(loaded.recommendations, report.recommendations);
+        assert!(stored_path.starts_with(&reports_dir));
+        assert_eq!(
+            result.summary.source_path.as_deref(),
+            Some(expected_source.as_str())
+        );
+    }
+
+    #[test]
+    fn list_reports_drops_entries_outside_report_store() {
+        let dir = tempdir().expect("temp dir");
+        fs::create_dir_all(dir.path().join("reports")).expect("create reports dir");
+
+        let outside = dir.path().join("outside-report.json");
+        fs::write(&outside, "{}").expect("write outside report");
+        let malicious_index = serde_json::json!({
+            "reports": [
+                {
+                    "scan_id": "escaped",
+                    "generated_at": "2026-04-10T00:00:00Z",
+                    "report_version": "1.3.0",
+                    "roots": [],
+                    "backend": "native",
+                    "warnings_count": 0,
+                    "recommendation_count": 0,
+                    "stored_report_path": outside,
+                    "source_path": null,
+                    "imported": false
+                }
+            ]
+        });
+        fs::write(
+            dir.path().join("index.json"),
+            serde_json::to_string_pretty(&malicious_index).expect("serialize index"),
+        )
+        .expect("write index");
+
+        let summaries = list_reports(Some(dir.path())).expect("list reports");
+
+        assert!(summaries.is_empty());
     }
 
     fn sample_report(

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -11,3 +11,6 @@ serde.workspace = true
 serde_json.workspace = true
 storage-strategist-core = { path = "../core" }
 uuid.workspace = true
+
+[dev-dependencies]
+tempfile = "3.16"

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -396,12 +396,21 @@ fn lock_sessions() -> Result<std::sync::MutexGuard<'static, HashMap<String, Scan
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::time::{Duration, Instant};
 
     use super::{
-        cancel_scan, doctor, get_scan_session, poll_scan_events, start_scan, ScanRequest,
-        ScanSessionStatus,
+        cancel_scan, doctor, get_report, get_scan_session, import_report, poll_scan_events,
+        start_scan, ScanRequest, ScanSessionStatus,
     };
+    use storage_strategist_core::model::{ActivitySignals, LargestFiles};
+    use storage_strategist_core::{
+        DiskInfo, DiskKind, DiskRole, DiskRoleHint, DiskStorageType, DuplicateGroup,
+        DuplicateIntent, DuplicateIntentLabel, EstimatedImpact, LocalityClass, PathStats,
+        PerformanceClass, Recommendation, RecommendationEvidence, RecommendationEvidenceKind,
+        Report, RiskLevel, ScanBackendKind, ScanMetadata, ScanMetrics,
+    };
+    use tempfile::tempdir;
 
     #[test]
     fn start_scan_creates_session_and_events() {
@@ -443,5 +452,160 @@ mod tests {
     fn doctor_returns_runtime_snapshot() {
         let info = doctor();
         assert!(info.read_only_mode);
+    }
+
+    #[test]
+    fn imported_reports_round_trip_through_service_without_reanalysis() {
+        let dir = tempdir().expect("temp dir");
+        let source = dir.path().join("legacy-report.json");
+        let report = sample_report("../legacy-report");
+        fs::write(
+            &source,
+            serde_json::to_string_pretty(&report).expect("serialize report"),
+        )
+        .expect("write source report");
+
+        let result = import_report(&source, Some(dir.path())).expect("import report");
+        let loaded = get_report(&report.scan_id, Some(dir.path())).expect("load imported report");
+
+        assert_eq!(loaded.recommendations, report.recommendations);
+        assert_eq!(loaded.policy_decisions, report.policy_decisions);
+        assert_eq!(loaded.rule_traces, report.rule_traces);
+        assert_eq!(
+            loaded.scan_metrics.contradiction_count,
+            report.scan_metrics.contradiction_count
+        );
+        assert!(result.summary.imported);
+    }
+
+    fn sample_report(scan_id: &str) -> Report {
+        Report {
+            report_version: "1.3.0".to_string(),
+            generated_at: "2026-04-10T00:00:00Z".to_string(),
+            scan_id: scan_id.to_string(),
+            scan: ScanMetadata {
+                roots: vec!["D:\\".to_string()],
+                max_depth: None,
+                excludes: Vec::new(),
+                dedupe: false,
+                dedupe_min_size: 0,
+                dry_run: true,
+                backend: ScanBackendKind::Native,
+                progress: false,
+                min_ratio: None,
+                emit_progress_events: false,
+                progress_interval_ms: 250,
+            },
+            scan_metrics: ScanMetrics {
+                contradiction_count: 2,
+                ..ScanMetrics::default()
+            },
+            scan_progress_summary: Default::default(),
+            backend_parity: None,
+            disks: vec![DiskInfo {
+                name: "Disk".to_string(),
+                mount_point: "D:\\".to_string(),
+                total_space_bytes: 1_000,
+                free_space_bytes: 400,
+                disk_kind: DiskKind::Ssd,
+                file_system: Some("ntfs".to_string()),
+                storage_type: DiskStorageType::Ssd,
+                locality_class: LocalityClass::LocalPhysical,
+                locality_confidence: 1.0,
+                locality_rationale: "fixture".to_string(),
+                is_os_drive: false,
+                is_removable: false,
+                vendor: None,
+                model: None,
+                interface: None,
+                rotational: None,
+                hybrid: None,
+                performance_class: PerformanceClass::Balanced,
+                performance_confidence: 1.0,
+                performance_rationale: "fixture".to_string(),
+                eligible_for_local_target: true,
+                ineligible_reasons: Vec::new(),
+                metadata_notes: Vec::new(),
+                role_hint: DiskRoleHint {
+                    role: DiskRole::ActiveWorkload,
+                    confidence: 0.8,
+                    evidence: vec!["fixture".to_string()],
+                },
+                target_role_eligibility: Vec::new(),
+            }],
+            paths: vec![PathStats {
+                root_path: "D:\\Demo".to_string(),
+                disk_mount: Some("D:\\".to_string()),
+                total_size_bytes: 600,
+                file_count: 12,
+                directory_count: 4,
+                largest_files: LargestFiles {
+                    entries: Vec::new(),
+                },
+                largest_directories: Vec::new(),
+                file_type_summary: storage_strategist_core::FileTypeSummary {
+                    top_extensions: Vec::new(),
+                    other_files: 0,
+                    other_bytes: 0,
+                    total_files: 0,
+                    total_bytes: 0,
+                },
+                activity: ActivitySignals {
+                    recent_files: 0,
+                    stale_files: 0,
+                    unknown_modified_files: 0,
+                },
+            }],
+            categories: Vec::new(),
+            duplicates: vec![DuplicateGroup {
+                size_bytes: 10,
+                hash: "hash-1".to_string(),
+                files: Vec::new(),
+                total_wasted_bytes: 5,
+                intent: DuplicateIntent {
+                    label: DuplicateIntentLabel::LikelyRedundant,
+                    rationale: "fixture".to_string(),
+                },
+            }],
+            recommendations: vec![Recommendation {
+                id: "stored-rec".to_string(),
+                title: "Stored recommendation".to_string(),
+                rationale: "Persisted rationale".to_string(),
+                confidence: 0.42,
+                target_mount: Some("D:\\".to_string()),
+                policy_safe: false,
+                policy_rules_applied: vec!["stored_policy".to_string()],
+                policy_rules_blocked: vec!["blocked_policy".to_string()],
+                evidence: vec![RecommendationEvidence {
+                    kind: RecommendationEvidenceKind::Warning,
+                    label: "Stored evidence".to_string(),
+                    detail: "Imported reports should round-trip unchanged.".to_string(),
+                    path: Some("D:\\Demo".to_string()),
+                    mount_point: Some("D:\\".to_string()),
+                    duplicate_hash: None,
+                }],
+                next_steps: vec!["Review stored evidence".to_string()],
+                estimated_impact: EstimatedImpact {
+                    space_saving_bytes: Some(10),
+                    performance: Some("Stored performance note".to_string()),
+                    risk_notes: Some("Stored risk note".to_string()),
+                },
+                risk_level: RiskLevel::High,
+            }],
+            policy_decisions: vec![storage_strategist_core::PolicyDecision {
+                policy_id: "stored_policy".to_string(),
+                recommendation_id: "stored-rec".to_string(),
+                action: storage_strategist_core::PolicyAction::Blocked,
+                rationale: "Stored policy rationale".to_string(),
+            }],
+            rule_traces: vec![storage_strategist_core::RuleTrace {
+                rule_id: "stored_rule".to_string(),
+                status: storage_strategist_core::RuleTraceStatus::Rejected,
+                detail: "Stored trace detail".to_string(),
+                recommendation_id: Some("stored-rec".to_string()),
+                confidence: Some(0.13),
+            }],
+            warnings: vec!["stored warning".to_string()],
+        }
     }
 }


### PR DESCRIPTION
PR title must use Conventional Commit format: `type(scope): description`

## Linked issue

Linked issue: #10

## Summary

This hardens saved-report path boundaries and stabilizes saved-report reopen/import behavior.

- unsafe `scan_id` values are confined to safe report-store paths and stale index entries outside the store are ignored
- reopening or importing a saved report now preserves the stored recommendations, policy decisions, and rule traces instead of recomputing them from current analyzer state
- the desktop workbench now preserves the real stored report path so markdown and diagnostics exports use the correct provenance and output naming

## Affected scope

- [ ] core
- [ ] cli
- [x] desktop
- [ ] compliance
- [ ] infra
- [ ] docs
- [x] shared

## Validation

- [x] fmt
- [x] clippy
- [x] test
- [x] compliance checks
- [x] desktop smoke
- [x] Other validation is described below
- [ ] Not run (reason described below)

Validation notes:
- `cd apps/desktop/src-tauri && cargo check`

## Visible UI changes

- [x] No visible UI changes
- [ ] Screenshot(s) or preview link added below

UI evidence:
- Desktop behavior changed for reopen/import/export provenance, but there is no visual design change.

## Compliance impact

- [x] No compliance/provenance changes
- [ ] Compliance or provenance updates are included
- [ ] `provenance/imported_code.json` updated where applicable
- [ ] `THIRD_PARTY_NOTICES.md` updated where applicable

Compliance notes:
- No imported or derived code was added.

## Docs impact

- [x] No docs changes required
- [ ] Docs updated in this PR
- [ ] Docs follow-up issue linked below

Docs notes:
- Behavior is covered by tests; no contributor or user-facing docs required updating for this stabilization fix.

## Rollback notes

- [x] Not risky / not production impacting
- [ ] Rollback plan included below

Rollback plan:
- Revert the PR squash commit to restore the previous reopen/import flow if needed.

## Trivial docs-only exception

- [ ] This PR changes only `docs/**`, `*.md`, or `*.txt`
- [ ] This PR does not touch workflows, configs, schemas, scripts, or code
